### PR TITLE
i18n（国際化）を導入

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "acount"
+    ]
+}

--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,15 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+# Tailwind CSS - ユーティリティファーストなCSSフレームワーク
+gem "tailwindcss-rails"
+
+# Devise - 認証ソリューション
+gem "devise"
+
+# rails-i18n - 多言語対応（日本語含む）
+gem "rails-i18n"
+
 group :development, :test do
   # debug - デバッグツール
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
@@ -76,8 +85,6 @@ group :development do
   # web-console - ブラウザ上でのデバッグコンソール
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
-
-  gem "htmlbeautifier"
 end
 
 group :test do
@@ -91,8 +98,3 @@ group :test do
   # minitest - テストの安定性向上のためv5に固定
   gem "minitest", "~> 5.25"
 end
-
-# Tailwind CSS - ユーティリティファーストなCSSフレームワーク
-gem "tailwindcss-rails"
-
-gem "devise"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,6 @@ GEM
     erubi (1.13.1)
     globalid (1.3.0)
       activesupport (>= 6.1)
-    htmlbeautifier (1.4.3)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
@@ -226,6 +225,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (7.0.10)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.2.3)
       actionpack (= 7.2.3)
       activesupport (= 7.2.3)
@@ -353,13 +355,13 @@ DEPENDENCIES
   cssbundling-rails
   debug
   devise
-  htmlbeautifier
   jbuilder
   jsbundling-rails
   minitest (~> 5.25)
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.2)
+  rails-i18n
   rubocop-rails-omakase
   selenium-webdriver
   sprockets-rails

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,44 +1,36 @@
 <div class="min-h-screen bg-base-200 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
   <div class="card w-full max-w-md bg-base-100 shadow-xl">
     <div class="card-body">
-      <h2 class="card-title text-3xl font-bold text-center justify-center mb-6">新規登録</h2>
+      <h2 class="card-title text-3xl font-bold text-center justify-center mb-6"><%= t('.title') %></h2>
 
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
 
         <div class="form-control w-full">
-          <%= f.label :name, class: "label" do %>
-            <span class="label-text font-semibold">名前</span>
-          <% end %>
+          <%= f.label :name, class: "label"%>
           <%= f.text_field :name, autofocus: true, class: "input input-bordered w-full" %>
         </div>
 
         <div class="form-control w-full mt-4">
-          <%= f.label :email, class: "label" do %>
-            <span class="label-text font-semibold">メールアドレス</span>
-          <% end %>
+          <%= f.label :email, class: "label" %>
           <%= f.email_field :email, autocomplete: "email", class: "input input-bordered w-full" %>
         </div>
 
         <div class="form-control w-full mt-4">
-          <%= f.label :password, class: "label" do %>
-            <span class="label-text font-semibold">パスワード</span>
+          <%= f.label :password, class: "label" %>
             <% if @minimum_password_length %>
               <span class="label-text-alt text-base-content/70">(<%= @minimum_password_length %> 文字以上)</span>
             <% end %>
-          <% end %>
           <%= f.password_field :password, autocomplete: "new-password", class: "input input-bordered w-full" %>
         </div>
 
         <div class="form-control w-full mt-4">
-          <%= f.label :password_confirmation, class: "label" do %>
-            <span class="label-text font-semibold">パスワード確認</span>
-          <% end %>
+          <%= f.label :password_confirmation, class: "label" %>
           <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "input input-bordered w-full" %>
         </div>
 
         <div class="form-control mt-6">
-          <%= f.submit "新規登録", class: "btn btn-primary w-full" %>
+          <%= f.submit t('helpers.submit.create'), class: "btn btn-primary w-full" %>
         </div>
       <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,22 +1,18 @@
 <div class="min-h-screen bg-base-200 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
   <div class="card w-full max-w-md bg-base-100 shadow-xl">
     <div class="card-body">
-      <h2 class="card-title text-3xl font-bold text-center justify-center mb-6">ログイン</h2>
+      <h2 class="card-title text-3xl font-bold text-center justify-center mb-6"><%= t('.title') %></h2>
 
       <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
 
         <%= render "devise/shared/error_messages", resource: resource %>
         <div class="form-control w-full">
-          <%= f.label :email, class: "label" do %>
-            <span class="label-text font-semibold">メールアドレス</span>
-          <% end %>
+          <%= f.label :email, class: "label" %>
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered w-full" %>
         </div>
 
         <div class="form-control w-full mt-4">
-          <%= f.label :password, class: "label" do %>
-            <span class="label-text font-semibold">パスワード</span>
-          <% end %>
+          <%= f.label :password, class: "label" %>
           <%= f.password_field :password, autocomplete: "current-password", class: "input input-bordered w-full" %>
         </div>
 
@@ -24,13 +20,13 @@
           <div class="form-control mt-4">
             <label class="label cursor-pointer justify-start gap-2">
               <%= f.check_box :remember_me, class: "checkbox checkbox-primary" %>
-              <span class="label-text">ログイン状態を保持する</span>
+              <span class="label-text"><%= t('.stay_logged_in') %></span>
             </label>
           </div>
         <% end %>
 
         <div class="form-control mt-6">
-          <%= f.submit "ログイン", class: "btn btn-primary w-full" %>
+          <%= f.submit t('helpers.submit.login'), class: "btn btn-primary w-full" %>
         </div>
       <% end %>
 

--- a/app/views/shared/_drawer_menu.html.erb
+++ b/app/views/shared/_drawer_menu.html.erb
@@ -5,11 +5,11 @@
     <li>
       <summary>〇〇さん、ようこそ！</summary>
       <details open>
-        <summary>私のミニメモリー</summary>
+        <summary><%= t('drawer.summary.my_mini_memory') %></summary>
         <ul>
-          <li><%= link_to "新規投稿", "#" %></li>
-          <li><%= link_to "思い出一覧（ミニメモリー）", memories_path %></li>
-          <li><%= link_to "子と楽しむ", "#" %></li>
+          <li><%= link_to t('drawer.list.create_memory'), "#" %></li>
+          <li><%= link_to t('drawer.list.memory_index'), memories_path %></li>
+          <li><%= link_to t('drawer.list.enjoy_with_child'), "#" %></li>
         </ul>
       </details>
     </li>
@@ -17,25 +17,25 @@
 
   <li>
     <details>
-      <summary>みんなのミニメモリー</summary>
+        <summary><%= t('drawer.summary.everyone_mini_memory') %></summary>
       <ul>
-        <li><%= link_to "掲示板", "#" %></li>
+        <li><%= link_to t('drawer.list.board'), "#" %></li>
       </ul>
     </details>
   </li>
 
   <li>
     <details>
-      <summary>アカウント</summary>
+      <summary><%= t('drawer.summary.account') %></summary>
       <% if user_signed_in? %>
         <ul>
-          <li><%= link_to "マイページ", "#" %></li>
-          <li><%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete } %></li>
+          <li><%= link_to t('drawer.list.mypage'), "#" %></li>
+          <li><%= link_to t('drawer.list.logout'), destroy_user_session_path, data: { turbo_method: :delete } %></li>
         </ul>
       <% else %>
         <ul>
-          <li><%= link_to "新規登録", new_user_registration_path %></li>
-          <li><%= link_to "ログイン", new_user_session_path %></li>
+          <li><%= link_to t('drawer.list.user_create'), new_user_registration_path %></li>
+          <li><%= link_to t('drawer.list.login'), new_user_session_path %></li>
         </ul>
       <% end %>
     </details>
@@ -43,11 +43,11 @@
 
   <li>
     <details>
-      <summary>その他</summary>
+      <summary><%= t('drawer.summary.others') %></summary>
       <ul>
-        <li><%= link_to "利用規約", "#" %></li>
-        <li><%= link_to "プライバシーポリシー", "#" %></li>
-        <li><%= link_to "お問い合わせ", "#" %></li>
+        <li><%= link_to t('drawer.list.terms_of_service'), "#" %></li>
+        <li><%= link_to t('drawer.list.privacy_policy'), "#" %></li>
+        <li><%= link_to t('drawer.list.contact'), "#" %></li>
       </ul>
     </details>
   </li>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -34,8 +34,8 @@
       <%# ミニメモリボタン %>
       <%= link_to "#", class: "flex flex-col items-center justify-center text-xs" do %>
         <span class="text-xl">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z" />
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5">
+            <path d="M10.75 16.82A7.462 7.462 0 0 1 15 15.5c.71 0 1.396.098 2.046.282A.75.75 0 0 0 18 15.06v-11a.75.75 0 0 0-.546-.721A9.006 9.006 0 0 0 15 3a8.963 8.963 0 0 0-4.25 1.065V16.82ZM9.25 4.065A8.963 8.963 0 0 0 5 3c-.85 0-1.673.118-2.454.339A.75.75 0 0 0 2 4.06v11a.75.75 0 0 0 .954.721A7.506 7.506 0 0 1 5 15.5c1.579 0 3.042.487 4.25 1.32V4.065Z" />
           </svg>
         </span>
         <span>ミニメモリ</span>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -16,7 +16,7 @@
   <!-- ユーザーアイコン -->
   <div class="navbar-end">
     <% if user_signed_in? %>
-      <%= link_to "#", class: "btn btn-ghost btn-circle", aria: { label: "マイページ" } do %>
+      <%= link_to "#", class: "btn btn-ghost btn-circle", aria: { label: t('header.mypage') } do %>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
           <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
         </svg>
@@ -29,7 +29,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
             </svg>
           </span>
-          <span>新規登録</span>
+          <span><%= t('header.user_create') %></span>
         <% end %>
         <%= link_to new_user_session_path, class: "flex flex-col items-center justify-center text-xs" do %>
           <span class="text-xl">
@@ -37,7 +37,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15M12 9l-3 3m0 0 3 3m-3-3h12.75" />
             </svg>
           </span>
-          <span>ログイン</span>
+          <span><%= t('header.login') %></span>
         <% end %>
       </div>
     <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,8 @@ module Myapp
 
     # デフォルトのタイムゾーンを日本時間に設定
     config.time_zone = "Tokyo"
+    # デフォルトの言語設定を日本語に設定
+    config.i18n.default_locale = :ja
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,10 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+    attributes:
+      user:
+        email: メールアドレス
+        name: 名前
+        password: パスワード
+        password_confirmation: パスワード確認

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,44 @@
+ja:
+  helpers:
+    submit:
+      create: 登録
+      submit: 保存
+      update: 更新
+      login: ログイン
+    label:
+      name: 名前
+      email: メールアドレス
+      password: パスワード
+      password_confirmation: パスワード確認
+  devise:
+    registrations:
+      new:
+        title: 新規登録
+      edit:
+        title: アカウント編集
+    sessions:
+      new:
+        title: ログイン
+        stay_logged_in: ログイン状態を保持する
+  header:
+    mypage: マイページ
+    user_create: 新規登録
+    login: ログイン
+  drawer:
+    summary:
+      my_mini_memory: 私のミニメモリー
+      everyone_mini_memory: みんなのミニメモリー
+      account: アカウント
+      others: その他
+    list:
+      create_memory: 新規投稿
+      memory_index: 思い出一覧
+      enjoy_with_child: 子と楽しむ
+      board: 掲示板
+      mypage: マイページ
+      logout: ログアウト
+      user_create: 新規登録
+      login: ログイン
+      terms_of_service: 利用規約
+      privacy_policy: プライバシーポリシー
+      contact: お問い合わせ


### PR DESCRIPTION
# 概要
i18nを導入し、画面表示を日本語化した。
# 詳細
i18n を有効化し、デフォルト言語を日本語に設定した。
config/locals/activerecord/ja.yml, config/locals/views/ja.ymlを追加した。
deviseの画面上の文言を i18n 経由で取得するよう修正した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * アプリケーションが多言語対応の基盤を備えるようになりました。
  * 日本語での完全なローカライゼーション対応を実装しました。UI全体で日本語テキストが統一されました。

* **その他**
  * 依存パッケージを追加・整理しました。
  * 開発環境の設定を最適化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->