### PR TITLE
[main] memory作成機能追加

### DIFF
--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -4,4 +4,23 @@ class MemoriesController < ApplicationController
   def index
     @my_memories = current_user.memories.includes(:user).order(created_at: :desc)
   end
+
+  def new
+    @memory = Memory.new
+  end
+
+  def create
+    @memory = current_user.memories.build(memory_params)
+    if @memory.save
+      redirect_to memories_path
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def memory_params
+    params.require(:memory).permit(:title, :description, :memory_date, :visibility)
+  end
 end

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -9,4 +9,11 @@ class Memory < ApplicationRecord
     unlisted: 1,  # 本人、非公開URLを知っている人のみ閲覧可能
     published: 2     # 掲示板にて誰でも閲覧可能、非公開URLを知っている人も閲覧可能
   }
+
+  # enumの選択肢を国際化対応した配列で返すヘルパーメソッド
+  def self.visibility_options_for_select
+    Memory.visibilities.keys.map do |key|
+      [ I18n.t("enums.memory.visibility.#{key}"), key ]
+    end
+  end
 end

--- a/app/views/memories/new.html.erb
+++ b/app/views/memories/new.html.erb
@@ -1,0 +1,38 @@
+<div class="max-w-3xl mx-auto px-4">
+  <h1 class="text-2xl font-bold mb-6">
+    <%= t('.title') %>
+  </h1>
+
+  <%= form_with model: @memory, class: "space-y-6" do |f| %>
+    <!--タイトル-->
+    <div class="form-control">
+      <%= f.label :title, class: "label" %>
+      <%= f.text_field :title, class: "input input-bordered w-full" %>
+    </div>
+
+    <!--思い出の説明-->
+    <div class="form-control">
+      <%= f.label :description, class: "label" %>
+      <%= f.text_area :description, class: "textarea textarea-bordered w-full", rows: 10 %>
+    </div>
+
+    <!-- 思い出の日付 -->
+    <div class="form-control">
+      <%= f.label :memory_date, class: "label" %>
+      <%= f.date_field :memory_date, class: "input input-bordered w-full" %>
+    </div>
+
+    <!-- 公開範囲 -->
+    <div class="form-control">
+      <%= f.label :visibility, class: "label" %>
+      <%= f.select :visibility,
+            Memory.visibility_options_for_select,
+            {},
+            class: "select select-bordered w-full" %>
+    </div>
+
+    <div>
+      <%= f.submit nil, class: "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_drawer_menu.html.erb
+++ b/app/views/shared/_drawer_menu.html.erb
@@ -7,7 +7,7 @@
       <details open>
         <summary><%= t('drawer.summary.my_mini_memory') %></summary>
         <ul>
-          <li><%= link_to t('drawer.list.create_memory'), "#" %></li>
+          <li><%= link_to t('drawer.list.create_memory'), new_memory_path %></li>
           <li><%= link_to t('drawer.list.memory_index'), memories_path %></li>
           <li><%= link_to t('drawer.list.enjoy_with_child'), "#" %></li>
         </ul>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -2,9 +2,21 @@ ja:
   activerecord:
     models:
       user: ユーザー
+      memory: 思い出
     attributes:
       user:
         email: メールアドレス
         name: 名前
         password: パスワード
         password_confirmation: パスワード確認
+      memory:
+        title: タイトル
+        description: 説明
+        memory_date: 思い出の日付
+        visibility: 公開範囲
+  enums:
+    memory:
+      visibility:
+        private_only: 非公開
+        unlisted: 非公開URLを知っている人のみ閲覧可能
+        published: 掲示板にて誰でも閲覧可能

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -20,6 +20,9 @@ ja:
       new:
         title: ログイン
         stay_logged_in: ログイン状態を保持する
+  memories:
+    new:
+      title: 思い出の新規投稿
   header:
     mypage: マイページ
     user_create: 新規登録

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
     sessions: "users/sessions"
   }
 
-  resources :memories, only: %i[index]
+  resources :memories, only: %i[index new create]
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
# 概要
memory作成機能を追加した。

# 詳細
memoryのルーティングnew, createを作成した。
memories_controller.rbにnewとcreateアクション追加した。
memoryの新規投稿画面viewを作成した。
表示をi18nに対応させた。
memory.rbにenum選択肢を表示するヘルパーメソッドを追加した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 新しいメモリー作成フォームを追加しました。タイトル、説明、思い出の日付、公開範囲を指定できます。
  * 非公開、非公開URLを知っている人のみ閲覧可能、掲示板で誰でも閲覧可能の3つの公開範囲オプションに対応しています。
  * メニューからメモリー作成ページへのナビゲーションが可能になりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->