### PR TITLE
memory登録のフォーム入力時エラーメッセージ実装、一部css修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,1 +1,2 @@
 @import "tailwindcss";
+@source inline("alert-success","alert-error");

--- a/app/views/memories/new.html.erb
+++ b/app/views/memories/new.html.erb
@@ -4,6 +4,7 @@
   </h1>
 
   <%= form_with model: @memory, class: "space-y-6" do |f| %>
+    <%= render 'shared/error_messages', object: f.object %>
     <!--タイトル-->
     <div class="form-control">
       <%= f.label :title, class: "label" %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object&.errors&.any? %>
+  <div id="error_explanation" data-turbo-cache="false" class="alert alert-error alert-soft flex flex-col items-start">
+    <ul class="mb-0 list-disc list-inside">
+      <% object.errors.each do |error| %>
+        <li><%= error.full_message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>


### PR DESCRIPTION
# 概要
memory新規登録におけるフォーム入力時のエラー表示を実装した。
daisyUIのalertのCSSが崩れていたので修正した。

# 詳細
app/views/shared/_error_messages.html.erbを作成し、memoryの新規登録ページにエラーメッセージを表示できるようにした。
動的なクラス表示をさせていた部分が本番環境で認識されず崩れていたため、app/assets/stylesheets/application.tailwind.cssにdaisyUIのクラスを明示し、動的なクラス表示に対応した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * フォームのバリデーションエラーが見やすいエラーメッセージとして表示されるようになりました。入力エラーが発生した場合、フォーム上部に詳細なエラー情報が表示されます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->