### PR TITLE
[main] index表示をmasonryに変更 

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,1 +1,35 @@
 @import "tailwindcss";
+
+/* Masonry */
+@layer utilities {
+  .masonry-grid {
+    position: relative;
+  }
+
+  /* デフォルト */
+  .masonry-sizer,
+  .masonry-item {
+    width: 15%;
+  }
+
+  /* 画面大 */
+  @media (max-width: 1024px) {
+    .masonry-sizer,
+    .masonry-item {
+      width: 20%;
+    }
+  }
+
+  /* 画面小 */
+  @media (max-width: 640px) {
+  .masonry-sizer,
+  .masonry-item {
+    width: 47%;
+  }
+}
+
+  /* 画像間の隙間 */
+  .masonry-item {
+    margin-bottom: 16px;
+  }
+}

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,4 +1,4 @@
 @import "tailwindcss";
 @plugin "daisyui" {
-  themes: pastel --default, night;
+  themes: autumn --default, night;
 }

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,4 +1,6 @@
 import { Application } from "@hotwired/stimulus"
 
+import "./masonry"
+
 const application = Application.start()
 export { application }

--- a/app/javascript/controllers/masonry.js
+++ b/app/javascript/controllers/masonry.js
@@ -1,0 +1,13 @@
+$(document).on("turbo:load", function () {
+  const $masonry = $(".masonry");
+  if ($masonry.length === 0) return; //もしmasonryクラスが見つからなければ処理を終了
+  if (!$.fn.imagesLoaded || !$.fn.masonry) return;
+
+  $masonry.imagesLoaded(function () { //要素内の全ての画像が読み込まれるまで待つ
+    $masonry.masonry({
+      itemSelector: ".masonry-item",  //どの要素を並べるかを指定
+      gutter: 20,  // 各アイテム間の左右の隙間を 20px に設定
+      percentPosition: true, //レスポンシブ対応のため、位置を % で計算
+    });
+  });
+});

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+
   </head>
 
   <body>
@@ -39,5 +40,15 @@
       </div>
 
     <%= render 'shared/footer' %>
+
+
+    <!-- jQueryのCDN -->
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    
+    <!-- MasonryのCDN 本体 -->
+    <script src="https://cdn.jsdelivr.net/npm/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
+
+    <!-- imagesLoadedのCDN 画像が全部読み込まれてから動くようにしてくれるもの -->
+    <script src="https://cdn.jsdelivr.net/npm/imagesloaded@4/imagesloaded.pkgd.min.js"></script>
   </body>
 </html>

--- a/app/views/memories/_memory.html.erb
+++ b/app/views/memories/_memory.html.erb
@@ -1,9 +1,11 @@
+<div class="masonry-item">
 <%= link_to memory_path(memory),
     id: "memory-id-#{memory.id}",
-    class: "card bg-base-100 w-full" do %>
+    class: "bg-base-100 block" do %>
 
   <figure>
   <div><%= image_tag memory.display_image, alt: memory.title, class: "w-full h-full object-cover" %></div>
   </figure>
 
 <% end %>
+</div>

--- a/app/views/memories/index.html.erb
+++ b/app/views/memories/index.html.erb
@@ -17,7 +17,7 @@
 
   <!-- 掲示板一覧 -->
   <% if @my_memories.present? %>
-    <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    <div class="masonry">
       <%= render @my_memories %>
     </div>
   <% else %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,7 @@
   <footer class="fixed bottom-0 w-full px-4 py-4">
     <div class="dock bg-base-100 text-neutral dock-xs md:dock-xl">
       <%# ホームボタン %>
-      <%= link_to "#", class: "flex flex-col items-center justify-center text-xs" do %>
+      <%= link_to root_path, class: "flex flex-col items-center justify-center text-xs" do %>
         <span class="text-xl">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
@@ -22,7 +22,7 @@
       <% end %>
 
       <%# 投稿ボタン %>
-      <%= link_to "#", class: "flex flex-col items-center justify-center text-xs" do %>
+      <%= link_to new_memory_path, class: "flex flex-col items-center justify-center text-xs" do %>
         <span class="text-xl">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v6m3-3H9m12 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
@@ -32,7 +32,7 @@
       <% end %>
 
       <%# ミニメモリボタン %>
-      <%= link_to "#", class: "flex flex-col items-center justify-center text-xs" do %>
+      <%= link_to memories_path, class: "flex flex-col items-center justify-center text-xs" do %>
         <span class="text-xl">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5">
             <path d="M10.75 16.82A7.462 7.462 0 0 1 15 15.5c.71 0 1.396.098 2.046.282A.75.75 0 0 0 18 15.06v-11a.75.75 0 0 0-.546-.721A9.006 9.006 0 0 0 15 3a8.963 8.963 0 0 0-4.25 1.065V16.82ZM9.25 4.065A8.963 8.963 0 0 0 5 3c-.85 0-1.673.118-2.454.339A.75.75 0 0 0 2 4.06v11a.75.75 0 0 0 .954.721A7.506 7.506 0 0 1 5 15.5c1.579 0 3.042.487 4.25 1.32V4.065Z" />


### PR DESCRIPTION
# 概要
memory(思い出)の一覧表示をmasonryに変更した。
フッターのリンクを設置した。
daisyUIのテーマを変更した。

# 詳細
masonry.jsをCDN形式で実装した。
フッターの新規投稿、HOME、ミニメモリにそれぞれリンクを設置した。
daisyUIのテーマを変更した。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * メモリアイテムの表示レイアウトが改善され、レスポンシブなマッソンリーグリッド形式が導入されました。

* **バグ修正**
  * フッターのナビゲーションリンク（HOME、新規投稿、ミニメモリ）が正常に機能するよう修正されました。

* **スタイル**
  * アプリケーションのテーマカラーがオータムテーマに変更されました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->