### PR TITLE
[main] フッターのアクティブ状態をページごとに表示

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,4 +45,8 @@ module ApplicationHelper
     end
     image_url("minimemory_ogp.png")
   end
+
+  def active_if(controller)
+    controller == controller_name ? "dock-active" : ""
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,7 +46,18 @@ module ApplicationHelper
     image_url("minimemory_ogp.png")
   end
 
+  # ナビゲーションのアクティブ状態を判定するヘルパーメソッド
   def active_if(controller)
     controller == controller_name ? "dock-active" : ""
+  end
+
+  # ミニメモリのリスト関連のアクティブ状態を判定するヘルパーメソッド
+  def active_if_memories_list
+    action_name.in?(%w[index show edit update destroy]) ? active_if("memories") : ""
+  end
+
+  # ミニメモリの投稿関連のアクティブ状態を判定するヘルパーメソッド
+  def active_if_memories_new
+    action_name.in?(%w[new create]) ? active_if("memories") : ""
   end
 end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,7 @@
   <footer class="fixed bottom-0 w-full px-4 py-4">
     <div class="dock bg-base-100 text-neutral dock-xs md:dock-xl">
       <%# ホームボタン %>
-      <%= link_to root_path, class: "flex flex-col items-center justify-center text-xs" do %>
+      <%= link_to root_path, class: "flex flex-col items-center justify-center text-xs #{active_if("dashboard")}" do %>
         <span class="text-xl">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
@@ -12,7 +12,7 @@
       <% end %>
 
       <%# ミニメモリボタン %>
-      <%= link_to memories_path, class: "flex flex-col items-center justify-center text-xs" do %>
+      <%= link_to memories_path, class: "flex flex-col items-center justify-center text-xs #{action_name.in?(%w[index show edit update destroy]) ? active_if("memories") : ""}" do %>
         <span class="text-xl">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5">
             <path d="M10.75 16.82A7.462 7.462 0 0 1 15 15.5c.71 0 1.396.098 2.046.282A.75.75 0 0 0 18 15.06v-11a.75.75 0 0 0-.546-.721A9.006 9.006 0 0 0 15 3a8.963 8.963 0 0 0-4.25 1.065V16.82ZM9.25 4.065A8.963 8.963 0 0 0 5 3c-.85 0-1.673.118-2.454.339A.75.75 0 0 0 2 4.06v11a.75.75 0 0 0 .954.721A7.506 7.506 0 0 1 5 15.5c1.579 0 3.042.487 4.25 1.32V4.065Z" />
@@ -22,7 +22,7 @@
       <% end %>
 
       <%# 投稿ボタン %>
-      <%= link_to new_memory_path, class: "flex flex-col items-center justify-center text-xs" do %>
+      <%= link_to new_memory_path, class: "flex flex-col items-center justify-center text-xs #{action_name.in?(%w[new create]) ? active_if("memories") : ""}" do %>
         <span class="text-xl">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v6m3-3H9m12 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
@@ -32,7 +32,7 @@
       <% end %>
 
       <%# 掲示板ボタン %>
-      <%= link_to public_memories_path, class: "flex flex-col items-center justify-center text-xs" do %>
+      <%= link_to public_memories_path, class: "flex flex-col items-center justify-center text-xs #{active_if("public_memories")}" do %>
         <span class="text-xl">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z" />
@@ -43,7 +43,7 @@
 
 
       <%# 楽しむボタン %>
-      <%= link_to memory_game_path, class: "flex flex-col items-center justify-center text-xs" do %>
+      <%= link_to memory_game_path, class: "flex flex-col items-center justify-center text-xs #{active_if("memory_games")}" do %>
         <span class="text-xl">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z" />

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -12,7 +12,7 @@
       <% end %>
 
       <%# ミニメモリボタン %>
-      <%= link_to memories_path, class: "flex flex-col items-center justify-center text-xs #{action_name.in?(%w[index show edit update destroy]) ? active_if("memories") : ""}" do %>
+      <%= link_to memories_path, class: "flex flex-col items-center justify-center text-xs #{active_if_memories_list}" do %>
         <span class="text-xl">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5">
             <path d="M10.75 16.82A7.462 7.462 0 0 1 15 15.5c.71 0 1.396.098 2.046.282A.75.75 0 0 0 18 15.06v-11a.75.75 0 0 0-.546-.721A9.006 9.006 0 0 0 15 3a8.963 8.963 0 0 0-4.25 1.065V16.82ZM9.25 4.065A8.963 8.963 0 0 0 5 3c-.85 0-1.673.118-2.454.339A.75.75 0 0 0 2 4.06v11a.75.75 0 0 0 .954.721A7.506 7.506 0 0 1 5 15.5c1.579 0 3.042.487 4.25 1.32V4.065Z" />
@@ -22,7 +22,7 @@
       <% end %>
 
       <%# 投稿ボタン %>
-      <%= link_to new_memory_path, class: "flex flex-col items-center justify-center text-xs #{action_name.in?(%w[new create]) ? active_if("memories") : ""}" do %>
+      <%= link_to new_memory_path, class: "flex flex-col items-center justify-center text-xs #{active_if_memories_new}" do %>
         <span class="text-xl">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v6m3-3H9m12 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />


### PR DESCRIPTION
## 概要
フッターのナビゲーションにアクティブ表示を追加した。

## 変更内容
- `active_if` ヘルパーを追加
- 各フッターリンクにアクティブ判定を追加
- `memories` は一覧系(`index show edit update destroy`)と投稿系(`new create`)でアクティブ対象を分離

## 備考
画面下部ナビから、現在地が分かりやすくなる想定。