### PR TITLE
パスワード最低文字数変更

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -178,7 +178,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly


### PR DESCRIPTION
## 概要
セキュリティ強化のためDeviseのパスワード最低文字数を6文字から8文字に変更した。

## 変更内容
- `config.password_length = 8..128` に変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **セキュリティ改善**
  * パスワードの最小文字数要件が6文字から8文字に変更されました。新規登録およびパスワード変更時には、より強力なパスワードが必要となります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->