### PR TITLE
アバター画像機能追加

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -49,7 +49,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # 許可する追加のパラメータがある場合は、それらをサニタイザーに追加(account_update用) - ストロングパラメータ
   def configure_account_update_params
-    devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :name, :avatar ])
   end
 
   # sign up後のリダイレクト先を指定(dashboard#top)

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -1,15 +1,19 @@
 class Memory < ApplicationRecord
+  # バリデーション
   validates :title, presence: true, length: { maximum: 255 }
   validates :description, presence: true, length: { maximum: 65_535 }
   validates :memory_date, presence: true
-
-  belongs_to :user
-
-  has_one_attached :image
-  validate :image_content_type
-  validate :image_size
   validates :image, presence: true
 
+  # アソシエーション
+  belongs_to :user
+  has_one_attached :image
+
+  # imageカスタムバリデーション
+  validate :image_content_type
+  validate :image_size
+
+  # enum公開範囲定義
   enum :visibility, {
     private_only: 0,   # 本人のみ閲覧可能
     # unlisted: 1,  # 家族グループメンバーのみ閲覧可能
@@ -19,15 +23,31 @@ class Memory < ApplicationRecord
   # 公開投稿のみを取得するスコープ
   scope :publicly_available, -> { where(visibility: :published) }
 
-  # enumの選択肢を国際化対応した配列で返すヘルパーメソッド
+  # 定数
+  ACCEPT_CONTENT_TYPE = [ "image/png", "image/jpg", "image/jpeg" ].freeze
+  MAX_IMAGE_SIZE = 10.megabytes
+
+  # enumの選択肢を国際化対応した配列で返すクラスメソッド
   def self.visibility_options_for_select
     Memory.visibilities.keys.map do |key|
       [ I18n.t("enums.memory.visibility.#{key}"), key ]
     end
   end
 
-  ACCEPT_CONTENT_TYPE = %w[image/jpeg image/jpg image/png image/webp]
-  MAX_IMAGE_SIZE = 10.megabytes
+  # 画像表示用メソッド
+  def display_image
+    return default_image unless image.attached?
+    return default_image unless image.content_type.in?(ACCEPT_CONTENT_TYPE)
+
+    image.variant(resize_to_limit: [ 200, 200 ])
+  end
+
+  # URLのパラメータとしてuuidを使用
+  def to_param
+    uuid
+  end
+
+  private
 
   # アップロード形式のバリデーション
   def image_content_type
@@ -35,6 +55,7 @@ class Memory < ApplicationRecord
       errors.add(:image, "はJPEG、JPG、PNGのみアップロード可能です")
     end
   end
+
   # 画像サイズのバリデーション
   def image_size
     if image.attached? && image.blob.byte_size > MAX_IMAGE_SIZE
@@ -42,24 +63,8 @@ class Memory < ApplicationRecord
     end
   end
 
-  # サムネイル表示用メソッド
-  def image_as_thumbnail
-    return unless image.attached? && image.content_type.in?(ACCEPT_CONTENT_TYPE)
-    image.variant(resize_to_limit: [ 200, 200 ])
-  end
-
   # default画像表示用メソッド
   def default_image
     "memory_placeholder.png"
-  end
-
-  # 画像表示用メソッド
-  def display_image
-    image_as_thumbnail || default_image
-  end
-
-  # URLのパラメータとしてuuidを使用
-  def to_param
-    uuid
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,9 +4,22 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: %i[line]
-  validates :name, presence: true
 
+  # 定数
+  ACCEPTED_CONTENT_TYPES = [ "image/png", "image/jpg", "image/jpeg" ].freeze
+  MAX_AVATAR_SIZE = 5.megabytes
+
+  # Active Storageのバリデーション
+  has_one_attached :avatar
+
+  # アソシエーション
   has_many :memories, dependent: :destroy
+
+  # バリデーション
+  validates :name, presence: true
+  validate :avatar_content_type
+  validate :avatar_size
+
 
   # OmniauthでLINEログインしたときに呼ばれるメソッド - 初回登録&二回目以降のログイン両方で使用
   def self.from_omniauth(auth)
@@ -27,5 +40,31 @@ class User < ApplicationRecord
     end
 
     user
+  end
+
+  # アバター画像が添付されているかを判定
+  def avatar_attached?
+    avatar&.attached?
+  end
+
+  # アバター画像のURLまたはイニシャルを返す
+  def avatar_display_initial
+    name&.slice(0, 1) || "?"
+  end
+
+  private
+
+  # アップロード形式のバリデーション
+  def avatar_content_type
+    if avatar.attached? && !avatar.content_type.in?(ACCEPTED_CONTENT_TYPES)
+      errors.add(:avatar, "はPNG、JPG、JPEG形式のみアップロード可能です")
+    end
+  end
+
+  # 画像サイズのバリデーション
+  def avatar_size
+    if avatar.attached? && avatar.blob.byte_size > MAX_AVATAR_SIZE
+      errors.add(:avatar, "は5MB以下にしてください")
+    end
   end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -19,8 +19,33 @@
 
     <div class="card bg-base-100 shadow-2xl border border-base-200">
       <div class="card-body p-6 gap-4">
-        <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+        <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, multipart: true }) do |f| %>
           <%= render "shared/error_messages", object: resource %>
+
+          <div class="flex flex-col items-center gap-2">
+            <% if resource.avatar.attached? %>
+              <div class="avatar">
+                <div class="w-20 h-20 rounded-full overflow-hidden">
+                  <%= image_tag resource.avatar, class: "w-full h-full object-cover", alt: resource.name %>
+                </div>
+              </div>
+            <% else %>
+              <div class="avatar placeholder">
+                <div class="bg-neutral text-neutral-content rounded-full w-20 h-20 flex items-center justify-center">
+                  <span class="text-2xl font-bold"><%= resource.name&.slice(0, 1) %></span>
+                </div>
+              </div>
+            <% end %>
+          </div>
+
+          <div class="form-control gap-1">
+            <%= f.label :avatar, class: "label py-0" do %>
+              <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60">アバター画像</span>
+            <% end %>
+            <%= f.file_field :avatar,
+                  accept: "image/png,image/jpg,image/jpeg",
+                  class: "file-input file-input-bordered file-input-sm w-full" %>
+          </div>
 
           <div class="form-control gap-1">
             <%= f.label :name, class: "label py-0" do %>

--- a/app/views/memories/show.html.erb
+++ b/app/views/memories/show.html.erb
@@ -46,14 +46,7 @@
 
       <%# 投稿者 %>
       <div class="flex items-center gap-3 pb-6 border-b border-base-200">
-      <%# アバター画像実装後はif文で表示切り替え %>
-        <div class="avatar placeholder">
-          <div class="bg-neutral text-neutral-content rounded-full w-9 h-9 flex items-center justify-center">
-            <span class="text-sm font-bold">
-              <%= @memory.user&.name&.slice(0, 1) || "?" %>
-            </span>
-          </div>
-        </div>
+        <%= render "shared/user_avatar", user: @memory.user, size: :md %>
         <span class="text-sm text-base-content/60">
           <span class="font-semibold text-base-content/80"><%= @memory.user&.name || t('defaults.unknown_user') %></span>
           <%= t('defaults.users_minimemory') %>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -19,6 +19,23 @@
 
     <div class="card bg-base-100 shadow-2xl border border-base-200">
       <div class="card-body p-6 gap-4">
+      <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60"><%= t('mypage.avatar') %></span>
+        <div class="flex flex-col items-center gap-3">
+          <% if @user.avatar.attached? %>
+            <div class="avatar">
+              <div class="w-20 h-20 rounded-full overflow-hidden">
+                <%= image_tag @user.avatar, class: "w-full h-full object-cover", alt: @user.name %>
+              </div>
+            </div>
+          <% else %>
+            <div class="avatar placeholder">
+              <div class="bg-neutral text-neutral-content rounded-full w-20 h-20 flex items-center justify-center">
+                <span class="text-2xl font-bold"><%= @user.name&.slice(0, 1) %></span>
+              </div>
+            </div>
+          <% end %>
+        </div>
+
         <div class="form-control gap-1">
           <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60"><%= t('mypage.user_name') %></span>
           <div class="w-full flex items-center justify-center">

--- a/app/views/public_memories/_memory.html.erb
+++ b/app/views/public_memories/_memory.html.erb
@@ -5,13 +5,7 @@
 
     <!-- ユーザー名 -->
     <div class="px-3 py-2 flex items-center gap-2 mt-1">
-      <div class="avatar placeholder">
-        <div class="bg-neutral text-neutral-content rounded-full w-6 h-6 flex items-center justify-center">
-          <span class="text-xs font-bold">
-            <%= memory.user&.name&.slice(0, 1) || "?" %>
-          </span>
-        </div>
-      </div>
+      <%= render "shared/user_avatar", user: memory.user, size: :sm %>
       <span class="text-xs text-base-content/60 truncate">
         <%= memory.user&.name || "不明なユーザー" %>
       </span>
@@ -22,7 +16,7 @@
         <%= image_tag memory.display_image,
             alt: memory.title,
             class: "w-full object-cover block" %>
-     </div>
+    </div>
 
     <!-- タイトル -->
     <div class="px-3 py-2">

--- a/app/views/public_memories/show.html.erb
+++ b/app/views/public_memories/show.html.erb
@@ -46,14 +46,7 @@
 
       <%# 投稿者 %>
       <div class="flex items-center gap-3 pb-6 border-b border-base-200">
-      <%# アバター画像実装後はif文で表示切り替え予定 %>
-        <div class="avatar placeholder">
-          <div class="bg-neutral text-neutral-content rounded-full w-9 h-9 flex items-center justify-center">
-            <span class="text-sm font-bold">
-              <%= @memory.user&.name&.slice(0, 1) || "?" %>
-            </span>
-          </div>
-        </div>
+        <%= render "shared/user_avatar", user: @memory.user, size: :md %>
         <span class="text-sm text-base-content/60">
           <span class="font-semibold text-base-content/80"><%= @memory.user&.name || t('defaults.unknown_user') %></span>
           <%= t('defaults.users_minimemory') %>

--- a/app/views/shared/_user_avatar.html.erb
+++ b/app/views/shared/_user_avatar.html.erb
@@ -1,0 +1,24 @@
+<%#
+  locals:
+    user   - User object (can be nil)
+    size   - :sm (w-6 h-6) or :md (w-9 h-9, default)
+%>
+<% size ||= :md %>
+<% size_classes = size == :sm ? "w-6 h-6" : "w-9 h-9" %>
+<% text_classes  = size == :sm ? "text-xs font-bold" : "text-sm font-bold" %>
+
+<% if user&.avatar_attached? %>
+  <div class="avatar">
+    <div class="<%= size_classes %> rounded-full overflow-hidden">
+      <%= image_tag user.avatar, class: "w-full h-full object-cover", alt: user.name %>
+    </div>
+  </div>
+<% else %>
+  <div class="avatar placeholder">
+    <div class="bg-neutral text-neutral-content rounded-full <%= size_classes %> flex items-center justify-center">
+      <span class="<%= text_classes %>">
+        <%= user&.avatar_display_initial %>
+      </span>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -40,7 +40,7 @@ ja:
         new: クリックして写真を選択
         edit: クリックして写真を変更
     format:
-      image: JPEG, PNG, JPG, Webp
+      image: JPEG, PNG, JPG
   devise:
     registrations:
       new:
@@ -67,6 +67,7 @@ ja:
     title: マイページ
     subtitle: アカウント情報を確認できます
     user_name: ユーザー名
+    avatar: アバター画像
   header:
     mypage: マイページ
     user_create: 新規登録


### PR DESCRIPTION
## 概要
ユーザーがアバター画像を設定できるようにし、マイページや投稿詳細、公開一覧などの投稿者表示に反映されるよう対応した。
あわせて、アバター未設定時はユーザー名の頭文字を表示する共通パーシャルを追加し、表示仕様を統一した。

## 変更内容
- `User` モデルにアバター画像の添付機能を追加
- アバター画像のファイル形式とサイズのバリデーションを追加
- アカウント編集画面からアバター画像をアップロードできるよう変更
- マイページに現在のアバター画像を表示
- 投稿詳細画面と公開メモリー一覧・詳細画面で投稿者アバターを表示するよう変更
- アバター未設定時は、ユーザー名の頭文字を表示する共通パーシャルを追加
- 画像形式の表示文言を実装に合わせて更新

## 補足
- アバター画像は `PNG / JPG / JPEG` のみアップロード可能
- アバター未設定時は `name` の先頭1文字を表示
- メモリー画像の表示メソッドも整理し、許可形式を `JPEG / JPG / PNG` に統一

## 主な変更ファイル
- app/models/user.rb
- app/controllers/users/registrations_controller.rb
- app/views/devise/registrations/edit.html.erb
- app/views/shared/_user_avatar.html.erb
- app/views/mypages/show.html.erb
- app/views/memories/show.html.erb
- app/views/public_memories/show.html.erb
- app/views/public_memories/_memory.html.erb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ユーザープロフィールにアバター機能を追加しました
  * マイページ、メモリー詳細ページにアバター表示を実装しました
  * アカウント編集フォームでアバターアップロードに対応しました

* **改善**
  * 画像形式の対応状況を更新（PNG、JPG、JPEGに対応）
  * アバター画像の検証機能を実装しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->