### PR TITLE
  [Release] 家族グループ機能実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,5 +11,4 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
     devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
   end
-
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,4 +11,5 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
     devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
   end
+
 end

--- a/app/controllers/family_groups_controller.rb
+++ b/app/controllers/family_groups_controller.rb
@@ -1,4 +1,5 @@
 class FamilyGroupsController < ApplicationController
+  before_action :set_family_group, only: [ :edit, :update, :show, :destroy ]
   before_action :authenticate_user!
 
   def new
@@ -8,6 +9,7 @@ class FamilyGroupsController < ApplicationController
   def create
     @family_group = FamilyGroup.new(family_group_params)
 
+    # グループ作成とオーナー登録をトランザクションでまとめる
     ActiveRecord::Base.transaction do
       @family_group.save!
       UserFamilyGroup.create!(user: current_user, family_group: @family_group, role: :owner)
@@ -20,8 +22,10 @@ class FamilyGroupsController < ApplicationController
     render :new, status: :unprocessable_entity
   end
 
+  def edit
+  end
+
   def update
-    @family_group = current_user.family_groups.find(params[:id])
     if @family_group.update(family_group_params)
       redirect_to @family_group, notice: "家族グループが更新されました"
     else
@@ -31,14 +35,22 @@ class FamilyGroupsController < ApplicationController
   end
 
   def show
-    @family_group = current_user.family_groups.find(params[:id])
+    # ログインユーザーのグループ内での役割を取得
+    @current_membership = @family_group.user_family_groups.find_by(user: current_user)
+    # オーナーかどうかを判定し、ビュー側で条件分岐できるようにインスタンス変数にセット
+    @is_owner = @current_membership&.owner?
+    # 最新の招待リンクを取得（存在する場合）
+    @latest_invitation = @family_group.invitations.order(created_at: :desc).first
   end
 
   def destroy
-    @family_group = current_user.family_groups.find(params[:id])
+    # オーナーのみグループ削除可能
     if @family_group.user_family_groups.find_by(user: current_user)&.owner?
-      @family_group.destroy
-      redirect_to dashboard_path, notice: "家族グループが削除されました"
+      if @family_group.destroy
+        redirect_to mypage_path, notice: "家族グループが削除されました"
+      else
+        redirect_to @family_group, alert: "家族グループの削除に失敗しました"
+      end
     else
       redirect_to @family_group, alert: "家族グループの削除はオーナーのみ可能です"
     end
@@ -48,5 +60,9 @@ class FamilyGroupsController < ApplicationController
 
   def family_group_params
     params.require(:family_group).permit(:name)
+  end
+
+  def set_family_group
+    @family_group = current_user.family_groups.find_by!(uuid: params[:uuid])
   end
 end

--- a/app/controllers/family_groups_controller.rb
+++ b/app/controllers/family_groups_controller.rb
@@ -1,6 +1,6 @@
 class FamilyGroupsController < ApplicationController
-  before_action :set_family_group, only: [ :edit, :update, :show, :destroy ]
   before_action :authenticate_user!
+  before_action :set_family_group, only: [ :edit, :update, :show, :destroy ]
 
   def new
     @family_group = FamilyGroup.new
@@ -20,6 +20,8 @@ class FamilyGroupsController < ApplicationController
   rescue ActiveRecord::RecordInvalid
     flash.now[:alert] = "家族グループの作成に失敗しました"
     render :new, status: :unprocessable_entity
+  rescue ActiveRecord::RecordNotUnique # ユーザーが既にグループに所属している場合の例外
+    redirect_to mypage_path, alert: "既に家族グループに所属しています"
   end
 
   def edit
@@ -40,7 +42,7 @@ class FamilyGroupsController < ApplicationController
     # オーナーかどうかを判定し、ビュー側で条件分岐できるようにインスタンス変数にセット
     @is_owner = @current_membership&.owner?
     # 最新の招待リンクを取得（存在する場合）
-    @latest_invitation = @family_group.invitations.order(created_at: :desc).first
+    @latest_invitation = @family_group.invitations.where("expires_at > ?", Time.current).order(created_at: :desc).first
   end
 
   def destroy

--- a/app/controllers/family_groups_controller.rb
+++ b/app/controllers/family_groups_controller.rb
@@ -1,0 +1,52 @@
+class FamilyGroupsController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    @family_group = FamilyGroup.new
+  end
+
+  def create
+    @family_group = FamilyGroup.new(family_group_params)
+
+    ActiveRecord::Base.transaction do
+      @family_group.save!
+      UserFamilyGroup.create!(user: current_user, family_group: @family_group, role: :owner)
+    end
+
+    redirect_to @family_group, notice: "家族グループが作成されました"
+
+  rescue ActiveRecord::RecordInvalid
+    flash.now[:alert] = "家族グループの作成に失敗しました"
+    render :new, status: :unprocessable_entity
+  end
+
+  def update
+    @family_group = current_user.family_groups.find(params[:id])
+    if @family_group.update(family_group_params)
+      redirect_to @family_group, notice: "家族グループが更新されました"
+    else
+      flash.now[:alert] = "家族グループの更新に失敗しました"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def show
+    @family_group = current_user.family_groups.find(params[:id])
+  end
+
+  def destroy
+    @family_group = current_user.family_groups.find(params[:id])
+    if @family_group.user_family_groups.find_by(user: current_user)&.owner?
+      @family_group.destroy
+      redirect_to dashboard_path, notice: "家族グループが削除されました"
+    else
+      redirect_to @family_group, alert: "家族グループの削除はオーナーのみ可能です"
+    end
+  end
+
+  private
+
+  def family_group_params
+    params.require(:family_group).permit(:name)
+  end
+end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -34,7 +34,7 @@ class InvitationsController < ApplicationController
     end
 
     unless user_signed_in?
-      session[:pending_invite_token] = params[:token]
+      store_location_for(:user, invitation_path(params[:token]))
       redirect_to new_user_session_path, alert: "参加するにはログインが必要です" and return
     end
 

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -5,9 +5,13 @@ class InvitationsController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[show]
   before_action :set_and_validate_invitation, only: %i[show join]
 
-  # 招待リンクの発行
+  # 招待リンクの発行(サーバー側でもう一度オーナーであることを確認)
   def create
-    family_group = current_user.family_groups.find(params[:family_group_id])
+    membership = current_user.user_family_groups.find_by!(
+      family_group_id: params[:family_group_id],
+      role: :owner
+      )
+    family_group = membership.family_group
     family_group.invitations.create!
     redirect_to family_group, notice: "招待リンクが発行されました"
   end
@@ -21,7 +25,7 @@ class InvitationsController < ApplicationController
     @family_group = @invitation.family_group
     UserFamilyGroup.create!(user: current_user, family_group: @family_group, role: :member) # メンバー権限として参加
     redirect_to mypage_path, notice: "#{@family_group.name}に参加しました"
-  rescue ActiveRecord::RecordInvalid
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
     redirect_to invitation_path(params[:token]), alert: "グループへの参加に失敗しました"
   end
 
@@ -34,15 +38,18 @@ class InvitationsController < ApplicationController
     # 招待リンクの有効性と期限切れのチェック
     if @invitation.nil? || @invitation.expired?
       redirect_to root_path, alert: "招待リンクが無効または期限切れです"
+      and return
     end
     # ログインしていない場合はURLを保存し、ログインページへリダイレクト
     unless user_signed_in?
       store_location_for(:user, invitation_path(params[:token]))
       redirect_to new_user_session_path, alert: "参加するにはログインが必要です"
+      and return
     end
     # すでにグループに所属しているユーザーは参加できないようにする
     if current_user.user_family_groups.exists?
       redirect_to mypage_path, alert: "すでにグループに参加しています"
+      and return
     end
   end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -38,18 +38,17 @@ class InvitationsController < ApplicationController
     # 招待リンクの有効性と期限切れのチェック
     if @invitation.nil? || @invitation.expired?
       redirect_to root_path, alert: "招待リンクが無効または期限切れです"
-      and return
     end
+
     # ログインしていない場合はURLを保存し、ログインページへリダイレクト
     unless user_signed_in?
       store_location_for(:user, invitation_path(params[:token]))
-      redirect_to new_user_session_path, alert: "参加するにはログインが必要です"
-      and return
+      return redirect_to new_user_session_path, alert: "参加するにはログインが必要です"
     end
+
     # すでにグループに所属しているユーザーは参加できないようにする
     if current_user.user_family_groups.exists?
       redirect_to mypage_path, alert: "すでにグループに参加しています"
-      and return
     end
   end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,11 +1,11 @@
 class InvitationsController < ApplicationController
-  # 招待リンクの発行はログイン必須
+  # 招待リンクの発行(createアクション)はログイン必須
   before_action :authenticate_user!, only: %i[create]
-  # 招待リンクを踏む側は未ログインの可能性があるためスキップ
-  skip_before_action :authenticate_user!, only: %i[show join]
+  # 招待リンクのURLはログイン不要でアクセスできる
+  skip_before_action :authenticate_user!, only: %i[show]
   before_action :set_and_validate_invitation, only: %i[show join]
 
-
+  # 招待リンクの発行
   def create
     family_group = current_user.family_groups.find(params[:family_group_id])
     family_group.invitations.create!
@@ -16,9 +16,10 @@ class InvitationsController < ApplicationController
     @family_group = @invitation.family_group
   end
 
+  # 招待リンクを踏んで参加するアクション
   def join
     @family_group = @invitation.family_group
-    UserFamilyGroup.create!(user: current_user, family_group: @family_group, role: :member)
+    UserFamilyGroup.create!(user: current_user, family_group: @family_group, role: :member) # メンバー権限として参加
     redirect_to mypage_path, notice: "#{@family_group.name}に参加しました"
   rescue ActiveRecord::RecordInvalid
     redirect_to invitation_path(params[:token]), alert: "グループへの参加に失敗しました"
@@ -26,20 +27,22 @@ class InvitationsController < ApplicationController
 
   private
 
+  # 招待リンクの検証と参加条件のチェックを共通化
   def set_and_validate_invitation
     @invitation = Invitation.find_by(token: params[:token])
 
+    # 招待リンクの有効性と期限切れのチェック
     if @invitation.nil? || @invitation.expired?
-      redirect_to root_path, alert: "招待リンクが無効または期限切れです" and return
+      redirect_to root_path, alert: "招待リンクが無効または期限切れです"
     end
-
+    # ログインしていない場合はURLを保存し、ログインページへリダイレクト
     unless user_signed_in?
       store_location_for(:user, invitation_path(params[:token]))
-      redirect_to new_user_session_path, alert: "参加するにはログインが必要です" and return
+      redirect_to new_user_session_path, alert: "参加するにはログインが必要です"
     end
-
+    # すでにグループに所属しているユーザーは参加できないようにする
     if current_user.user_family_groups.exists?
-      redirect_to mypage_path, alert: "すでにグループに参加しています" and return
+      redirect_to mypage_path, alert: "すでにグループに参加しています"
     end
   end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,0 +1,45 @@
+class InvitationsController < ApplicationController
+  # 招待リンクの発行はログイン必須
+  before_action :authenticate_user!, only: %i[create]
+  # 招待リンクを踏む側は未ログインの可能性があるためスキップ
+  skip_before_action :authenticate_user!, only: %i[show join]
+  before_action :set_and_validate_invitation, only: %i[show join]
+
+
+  def create
+    family_group = current_user.family_groups.find(params[:family_group_id])
+    family_group.invitations.create!
+    redirect_to family_group, notice: "招待リンクが発行されました"
+  end
+
+  def show
+    @family_group = @invitation.family_group
+  end
+
+  def join
+    @family_group = @invitation.family_group
+    UserFamilyGroup.create!(user: current_user, family_group: @family_group, role: :member)
+    redirect_to mypage_path, notice: "#{@family_group.name}に参加しました"
+  rescue ActiveRecord::RecordInvalid
+    redirect_to invitation_path(params[:token]), alert: "グループへの参加に失敗しました"
+  end
+
+  private
+
+  def set_and_validate_invitation
+    @invitation = Invitation.find_by(token: params[:token])
+
+    if @invitation.nil? || @invitation.expired?
+      redirect_to root_path, alert: "招待リンクが無効または期限切れです" and return
+    end
+
+    unless user_signed_in?
+      session[:pending_invite_token] = params[:token]
+      redirect_to new_user_session_path, alert: "参加するにはログインが必要です" and return
+    end
+
+    if current_user.user_family_groups.exists?
+      redirect_to mypage_path, alert: "すでにグループに参加しています" and return
+    end
+  end
+end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,5 +1,7 @@
 class MypagesController < ApplicationController
   def show
     @user = current_user
+    @family_group = current_user.family_groups.first
+    @current_membership = @family_group&.user_family_groups&.find_by(user: current_user)
   end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -4,7 +4,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     if user.persisted?
       sign_in user, event: :authentication
       flash[:notice] = "ログインしました"
-      redirect_to authenticated_root_path
+      redirect_to stored_location_for(user) || authenticated_root_path
     else
       session["devise.line_data"] = request.env["omniauth.auth"].except(:extra)
       redirect_to new_user_session_path, alert: "ユーザー情報の取得に失敗しました。"

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -28,8 +28,9 @@ class Users::SessionsController < Devise::SessionsController
   # end
 
   # サインイン後のリダイレクト先を指定
+  # 招待リンク経由の場合はstore_location_forで保存されたパスへ、それ以外はダッシュボードへ
   def after_sign_in_path_for(resource)
-    authenticated_root_path
+    stored_location_for(resource) || authenticated_root_path
   end
 
   # サインアウト後のリダイレクト先を指定

--- a/app/helpers/family_groups_helper.rb
+++ b/app/helpers/family_groups_helper.rb
@@ -1,0 +1,2 @@
+module FamilyGroupsHelper
+end

--- a/app/helpers/invitations_helper.rb
+++ b/app/helpers/invitations_helper.rb
@@ -1,0 +1,2 @@
+module InvitationsHelper
+end

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -6,13 +6,22 @@ export default class extends Controller {
 
   copy() {
     const text = this.sourceTarget.value
+    const original = this.buttonTarget.textContent
+
     navigator.clipboard.writeText(text).then(() => {
-      const original = this.buttonTarget.textContent
-      this.buttonTarget.textContent = "コピーしました"
+      this.buttonTarget.textContent = this.successLabelValue || "コピーしました"
       this.buttonTarget.disabled = true
       setTimeout(() => {
         this.buttonTarget.textContent = original
         this.buttonTarget.disabled = false
+      }, 2000)
+    }).catch((error) => {
+      console.error("クリップボードへのコピーに失敗しました:", error)
+      this.buttonTarget.textContent = "コピー失敗"
+      this.buttonTarget.classList.add("btn-error")
+      setTimeout(() => {
+        this.buttonTarget.textContent = original
+        this.buttonTarget.classList.remove("btn-error")
       }, 2000)
     })
   }

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["source", "button"]
+  static values = { successLabel: String }
+
+  copy() {
+    const text = this.sourceTarget.value
+    navigator.clipboard.writeText(text).then(() => {
+      const original = this.buttonTarget.textContent
+      this.buttonTarget.textContent = "コピーしました"
+      this.buttonTarget.disabled = true
+      setTimeout(() => {
+        this.buttonTarget.textContent = original
+        this.buttonTarget.disabled = false
+      }, 2000)
+    })
+  }
+}

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -7,6 +7,21 @@ export default class extends Controller {
   copy() {
     const text = this.sourceTarget.value
     const original = this.buttonTarget.textContent
+    const restoreFailureState = () => {
+      this.buttonTarget.textContent = original
+      this.buttonTarget.classList.remove("btn-error")
+    }
+    const showFailure = (error) => {
+      console.error("クリップボードへのコピーに失敗しました:", error)
+      this.buttonTarget.textContent = "コピー失敗"
+      this.buttonTarget.classList.add("btn-error")
+      setTimeout(restoreFailureState, 2000)
+    }
+
+    if (!navigator.clipboard?.writeText) {
+      showFailure(new Error("クリップボードへのコピーがサポートされていません"))
+      return
+    }
 
     navigator.clipboard.writeText(text).then(() => {
       this.buttonTarget.textContent = this.successLabelValue || "コピーしました"
@@ -15,14 +30,6 @@ export default class extends Controller {
         this.buttonTarget.textContent = original
         this.buttonTarget.disabled = false
       }, 2000)
-    }).catch((error) => {
-      console.error("クリップボードへのコピーに失敗しました:", error)
-      this.buttonTarget.textContent = "コピー失敗"
-      this.buttonTarget.classList.add("btn-error")
-      setTimeout(() => {
-        this.buttonTarget.textContent = original
-        this.buttonTarget.classList.remove("btn-error")
-      }, 2000)
-    })
+    }).catch(showFailure)
   }
 }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import ClipboardController from "./clipboard_controller"
+application.register("clipboard", ClipboardController)

--- a/app/models/family_group.rb
+++ b/app/models/family_group.rb
@@ -1,0 +1,7 @@
+class FamilyGroup < ApplicationRecord
+  has_many :user_family_groups, dependent: :destroy
+  has_many :users, through: :user_family_groups
+  has_many :invitations, dependent: :destroy
+
+  validates :name, presence: true
+end

--- a/app/models/family_group.rb
+++ b/app/models/family_group.rb
@@ -4,4 +4,9 @@ class FamilyGroup < ApplicationRecord
   has_many :invitations, dependent: :destroy
 
   validates :name, presence: true
+
+  # URLのパラメータとしてuuidを使用
+  def to_param
+    uuid
+  end
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -5,7 +5,7 @@ class Invitation < ApplicationRecord
 
   # 招待が期限切れかどうかを判断するメソッド
   def expired?
-    expires_at < Time.current
+    expires_at.nil? || expires_at < Time.current
   end
 
   private

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,0 +1,16 @@
+class Invitation < ApplicationRecord
+  belongs_to :family_group
+
+  before_create :generate_token
+
+  def expired?
+    expires_at < Time.current
+  end
+
+  private
+
+  def generate_token
+    self.token = SecureRandom.urlsafe_base64(16)
+    self.expires_at = 1.days.from_now
+  end
+end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -3,12 +3,14 @@ class Invitation < ApplicationRecord
 
   before_create :generate_token
 
+  # 招待が期限切れかどうかを判断するメソッド
   def expired?
     expires_at < Time.current
   end
 
   private
 
+  # 招待トークンを生成し、有効期限を設定
   def generate_token
     self.token = SecureRandom.urlsafe_base64(16)
     self.expires_at = 1.days.from_now

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,8 @@ class User < ApplicationRecord
 
   # アソシエーション
   has_many :memories, dependent: :destroy
+  has_many :user_family_groups, dependent: :destroy
+  has_many :family_groups, through: :user_family_groups
 
   # バリデーション
   validates :name, presence: true

--- a/app/models/user_family_group.rb
+++ b/app/models/user_family_group.rb
@@ -2,7 +2,7 @@ class UserFamilyGroup < ApplicationRecord
   belongs_to :user
   belongs_to :family_group
 
-  enum role: { owner: 0, member: 1 }  # defaultはmember
+  enum :role, { owner: 0, member: 1 }  # defaultはmember
 
   validate :max_one_group, on: :create
 

--- a/app/models/user_family_group.rb
+++ b/app/models/user_family_group.rb
@@ -1,0 +1,16 @@
+class UserFamilyGroup < ApplicationRecord
+  brlongs_to :user
+  belongs_to :family_group
+
+  enum role: { owner: 0, member: 1 }  # defaultはmember
+
+  validates :max_three_groupa, on: :create
+
+  private
+
+  def max_three_groupa
+    if user.user_family_groups.count >= 3
+      errors.add(:base, "1人のユーザーは最大3つの家族グループに所属できます")
+    end
+  end
+end

--- a/app/models/user_family_group.rb
+++ b/app/models/user_family_group.rb
@@ -4,16 +4,5 @@ class UserFamilyGroup < ApplicationRecord
 
   enum :role, { owner: 0, member: 1 }  # defaultはmember
 
-  validate :max_one_group, on: :create
-
-  private
-
-  def max_one_group
-    if user.user_family_groups.count >= 1
-    return if user_id.blank? # user_idがnilの場合はバリデーションをスキップ（関連するユーザーがいないため）
-
-    if UserFamilyGroup.exists?(user_id: user_id)
-    errors.add(:base, "ユーザーは1つの家族グループにしか所属できません")
-    end
-  end
+  validates :user_id, uniqueness: { message: "は1つの家族グループにしか所属できません" }
 end

--- a/app/models/user_family_group.rb
+++ b/app/models/user_family_group.rb
@@ -1,16 +1,16 @@
 class UserFamilyGroup < ApplicationRecord
-  brlongs_to :user
+  belongs_to :user
   belongs_to :family_group
 
   enum role: { owner: 0, member: 1 }  # defaultはmember
 
-  validates :max_three_groupa, on: :create
+  validate :max_one_group, on: :create
 
   private
 
-  def max_three_groupa
-    if user.user_family_groups.count >= 3
-      errors.add(:base, "1人のユーザーは最大3つの家族グループに所属できます")
+  def max_one_group
+    if user.user_family_groups.count >= 1
+      errors.add(:base, "ユーザーは1つの家族グループにしか所属できません")
     end
   end
 end

--- a/app/models/user_family_group.rb
+++ b/app/models/user_family_group.rb
@@ -10,7 +10,10 @@ class UserFamilyGroup < ApplicationRecord
 
   def max_one_group
     if user.user_family_groups.count >= 1
-      errors.add(:base, "ユーザーは1つの家族グループにしか所属できません")
+    return if user_id.blank? # user_idがnilの場合はバリデーションをスキップ（関連するユーザーがいないため）
+
+    if UserFamilyGroup.exists?(user_id: user_id)
+    errors.add(:base, "ユーザーは1つの家族グループにしか所属できません")
     end
   end
 end

--- a/app/views/family_groups/new.html.erb
+++ b/app/views/family_groups/new.html.erb
@@ -1,4 +1,42 @@
-<div>
-  <h1 class="font-bold text-4xl">FamilyGroups#new</h1>
-  <p>Find me in app/views/family_groups/new.html.erb</p>
+<div class="min-h-screen bg-base-200 flex justify-center py-6 px-4">
+  <div class="fixed inset-0 overflow-hidden pointer-events-none">
+    <div class="absolute -top-24 -right-24 w-96 h-96 rounded-full opacity-10 bg-primary blur-3xl"></div>
+    <div class="absolute -bottom-24 -left-24 w-96 h-96 rounded-full opacity-10 bg-secondary blur-3xl"></div>
+  </div>
+
+  <div class="relative w-full max-w-2xl">
+    <div class="flex items-center gap-3 mb-4">
+      <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-primary/10 shrink-0">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-primary">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z" />
+        </svg>
+      </div>
+      <div>
+        <h1 class="text-xl font-bold tracking-tight leading-tight">家族グループを作成</h1>
+        <p class="text-base-content/50 text-xs">グループを作成して家族を招待しましょう</p>
+      </div>
+    </div>
+
+    <div class="card bg-base-100 shadow-2xl border border-base-200">
+      <div class="card-body p-6 gap-4">
+        <%= form_with model: @family_group do |f| %>
+          <%= render 'shared/error_messages', object: f.object %>
+
+          <div class="form-control gap-1">
+            <%= f.label :name, class: "label py-0" do %>
+              <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60">グループ名</span>
+            <% end %>
+            <%= f.text_field :name,
+                  placeholder: "例：田中家、山田ファミリー",
+                  class: "input input-bordered input-sm bg-base-200/50 focus:bg-base-100 focus:input-primary transition-all duration-200 w-full" %>
+          </div>
+
+          <div class="flex justify-end gap-2 pt-1 border-t border-base-200">
+            <%= link_to "キャンセル", mypage_path, class: "btn btn-ghost btn-sm" %>
+            <%= f.submit "グループを作成する", class: "btn btn-primary btn-sm px-6" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/family_groups/new.html.erb
+++ b/app/views/family_groups/new.html.erb
@@ -7,13 +7,13 @@
   <div class="relative w-full max-w-2xl">
     <div class="flex items-center gap-3 mb-4">
       <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-primary/10 shrink-0">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-primary">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-primary" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z" />
         </svg>
       </div>
       <div>
-        <h1 class="text-xl font-bold tracking-tight leading-tight">家族グループを作成</h1>
-        <p class="text-base-content/50 text-xs">グループを作成して家族を招待しましょう</p>
+        <h1 class="text-xl font-bold tracking-tight leading-tight"><%= t('mypage.family_group.new.title') %></h1>
+        <p class="text-base-content/50 text-xs"><%= t('mypage.family_group.new.subtitle') %></p>
       </div>
     </div>
 
@@ -27,13 +27,13 @@
               <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60">グループ名</span>
             <% end %>
             <%= f.text_field :name,
-                  placeholder: "例：田中家、山田ファミリー",
+                  placeholder: t('mypage.family_group.new.name_placeholder'),
                   class: "input input-bordered input-sm bg-base-200/50 focus:bg-base-100 focus:input-primary transition-all duration-200 w-full" %>
           </div>
 
           <div class="flex justify-end gap-2 pt-1 border-t border-base-200">
-            <%= link_to "キャンセル", mypage_path, class: "btn btn-ghost btn-sm" %>
-            <%= f.submit "グループを作成する", class: "btn btn-primary btn-sm px-6" %>
+            <%= link_to t('helpers.submit.cancel'), mypage_path, class: "btn btn-ghost btn-sm" %>
+            <%= f.submit t('mypage.family_group.new.create_group'), class: "btn btn-primary btn-sm px-6" %>
           </div>
         <% end %>
       </div>

--- a/app/views/family_groups/new.html.erb
+++ b/app/views/family_groups/new.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">FamilyGroups#new</h1>
+  <p>Find me in app/views/family_groups/new.html.erb</p>
+</div>

--- a/app/views/family_groups/new.html.erb
+++ b/app/views/family_groups/new.html.erb
@@ -24,7 +24,7 @@
 
           <div class="form-control gap-1">
             <%= f.label :name, class: "label py-0" do %>
-              <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60">グループ名</span>
+              <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60"><%= t('mypage.family_group.new.name_label') %></span>
             <% end %>
             <%= f.text_field :name,
                   placeholder: t('mypage.family_group.new.name_placeholder'),

--- a/app/views/family_groups/show.html.erb
+++ b/app/views/family_groups/show.html.erb
@@ -15,7 +15,7 @@
       </div>
       <div>
         <h1 class="text-xl font-bold tracking-tight leading-tight"><%= @family_group.name %></h1>
-        <p class="text-base-content/50 text-xs"><%= @family_group.users.count %>人のメンバー</p>
+        <p class="text-base-content/50 text-xs"><%= t('mypage.family_group.member_count', count: @family_group.users.count) %></p>
       </div>
     </div>
 
@@ -32,9 +32,9 @@
                 <span class="text-sm font-medium"><%= ufg.user.name %></span>
               </div>
               <% if ufg.owner? %>
-                <span class="badge badge-primary badge-sm">オーナー</span>
+                <span class="badge badge-primary badge-sm"><%= t('mypage.family_group.owner_badge') %></span>
               <% else %>
-                <span class="badge badge-ghost badge-sm">メンバー</span>
+                <span class="badge badge-ghost badge-sm"><%= t('mypage.family_group.member_badge') %></span>
               <% end %>
             </li>
           <% end %>
@@ -42,18 +42,17 @@
       </div>
     </div>
 
-    <!-- 招待リンク -->
+    <!-- 招待リンク (最新の招待リンクが存在し、かつ有効期限が切れていない場合) -->
     <div class="card bg-base-100 shadow-2xl border border-base-200">
       <div class="card-body p-6 gap-4">
         <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60">招待リンク</span>
 
-        <% latest_invitation = @family_group.invitations.order(created_at: :desc).first %>
-        <% if latest_invitation && !latest_invitation.expired? %>
+        <% if @latest_invitation && !@latest_invitation.expired? %>
           <div class="flex items-center gap-2" data-controller="clipboard">
             <input
               type="text"
               readonly
-              value="<%= invitation_url(latest_invitation.token) %>"
+              value="<%= invitation_url(@latest_invitation.token) %>"
               data-clipboard-target="source"
               class="input input-bordered input-sm bg-base-200/50 w-full text-xs" />
             <button
@@ -64,14 +63,14 @@
               コピー
             </button>
           </div>
-          <p class="text-xs text-base-content/40">有効期限：<%= l(latest_invitation.expires_at, format: :short) %></p>
+          <p class="text-xs text-base-content/40">有効期限：<%= l(@latest_invitation.expires_at, format: :short) %></p>
         <% end %>
 
         <!-- オーナーのみ招待リンク発行ボタンを表示 -->
-        <% if @family_group.user_family_groups.find_by(user: current_user)&.owner? %>
+        <% if @is_owner %>
           <%= form_with url: invitations_path, method: :post do |f| %>
             <%= f.hidden_field :family_group_id, value: @family_group.id %>
-            <%= f.submit latest_invitation && !latest_invitation.expired? ? "再発行する" : "招待リンクを発行する",
+            <%= f.submit @latest_invitation && !@latest_invitation.expired? ? "再発行する" : "招待リンクを発行する",
                   class: "btn btn-outline btn-sm w-full" %>
           <% end %>
         <% end %>
@@ -87,7 +86,7 @@
         マイページへ戻る
       <% end %>
 
-      <% if @family_group.user_family_groups.find_by(user: current_user)&.owner? %>
+      <% if @is_owner %>
         <%= link_to family_group_path(@family_group),
               data: { turbo_method: :delete, turbo_confirm: "グループを解散しますか？この操作は取り消せません。" },
               class: "btn btn-error btn-outline btn-sm gap-2" do %>

--- a/app/views/family_groups/show.html.erb
+++ b/app/views/family_groups/show.html.erb
@@ -47,7 +47,7 @@
       <!-- オーナーのみ招待リンク発行ボタンを表示 -->
       <div class="card bg-base-100 shadow-2xl border border-base-200">
         <div class="card-body p-6 gap-4">
-          <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60">招待リンク</span>
+          <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60"><%= t('mypage.family_group.show.invitation') %></span>
 
           <% if @latest_invitation && !@latest_invitation.expired? %>
             <div class="flex items-center gap-2" data-controller="clipboard">
@@ -62,16 +62,16 @@
                 data-clipboard-target="button"
                 data-action="click->clipboard#copy"
                 class="btn btn-primary btn-sm shrink-0">
-                コピー
+                <%= t('mypage.family_group.show.copy') %>
               </button>
             </div>
-            <p class="text-xs text-base-content/40">有効期限：<%= l(@latest_invitation.expires_at, format: :short) %></p>
+            <p class="text-xs text-base-content/40"><%= t('mypage.family_group.show.invitation_expires_at') %>: <%= l(@latest_invitation.expires_at, format: :short) %></p>
           <% end %>
 
         <!-- 招待リンク (最新の招待リンクが存在し、かつ有効期限が切れていない場合) -->
           <%= form_with url: invitations_path, method: :post do |f| %>
             <%= f.hidden_field :family_group_id, value: @family_group.id %>
-            <%= f.submit @latest_invitation && !@latest_invitation.expired? ? "再発行する" : "招待リンクを発行する",
+            <%= f.submit @latest_invitation && !@latest_invitation.expired? ? t('mypage.family_group.show.reissue_invitation') : t('mypage.family_group.show.generate_invitation'),
                   class: "btn btn-outline btn-sm w-full" %>
           <% end %>
         </div>
@@ -84,7 +84,7 @@
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18"/>
         </svg>
-        マイページへ戻る
+        <%= t('mypage.family_group.show.return_to_mypage') %>
       <% end %>
 
       <% if @is_owner %>
@@ -94,7 +94,7 @@
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
           </svg>
-          グループを解散する
+          <%= t('mypage.family_group.show.disband_group') %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/family_groups/show.html.erb
+++ b/app/views/family_groups/show.html.erb
@@ -1,4 +1,103 @@
-<div>
-  <h1 class="font-bold text-4xl">FamilyGroups#show</h1>
-  <p>Find me in app/views/family_groups/show.html.erb</p>
+<div class="min-h-screen bg-base-200 flex justify-center py-6 px-4">
+  <div class="fixed inset-0 overflow-hidden pointer-events-none">
+    <div class="absolute -top-24 -right-24 w-96 h-96 rounded-full opacity-10 bg-primary blur-3xl"></div>
+    <div class="absolute -bottom-24 -left-24 w-96 h-96 rounded-full opacity-10 bg-secondary blur-3xl"></div>
+  </div>
+
+  <div class="relative w-full max-w-2xl flex flex-col gap-4">
+
+    <!-- ヘッダー -->
+    <div class="flex items-center gap-3">
+      <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-primary/10 shrink-0">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-primary">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z" />
+        </svg>
+      </div>
+      <div>
+        <h1 class="text-xl font-bold tracking-tight leading-tight"><%= @family_group.name %></h1>
+        <p class="text-base-content/50 text-xs"><%= @family_group.users.count %>人のメンバー</p>
+      </div>
+    </div>
+
+    <!-- メンバー一覧 -->
+    <div class="card bg-base-100 shadow-2xl border border-base-200">
+      <div class="card-body p-6 gap-4">
+        <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60">メンバー</span>
+
+        <ul class="flex flex-col gap-3">
+          <% @family_group.user_family_groups.includes(:user).each do |ufg| %>
+            <li class="flex items-center justify-between">
+              <div class="flex items-center gap-3">
+                <%= render "shared/user_avatar", user: ufg.user, size: :md %>
+                <span class="text-sm font-medium"><%= ufg.user.name %></span>
+              </div>
+              <% if ufg.owner? %>
+                <span class="badge badge-primary badge-sm">オーナー</span>
+              <% else %>
+                <span class="badge badge-ghost badge-sm">メンバー</span>
+              <% end %>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+
+    <!-- 招待リンク -->
+    <div class="card bg-base-100 shadow-2xl border border-base-200">
+      <div class="card-body p-6 gap-4">
+        <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60">招待リンク</span>
+
+        <% latest_invitation = @family_group.invitations.order(created_at: :desc).first %>
+        <% if latest_invitation && !latest_invitation.expired? %>
+          <div class="flex items-center gap-2" data-controller="clipboard">
+            <input
+              type="text"
+              readonly
+              value="<%= invitation_url(latest_invitation.token) %>"
+              data-clipboard-target="source"
+              class="input input-bordered input-sm bg-base-200/50 w-full text-xs" />
+            <button
+              type="button"
+              data-clipboard-target="button"
+              data-action="click->clipboard#copy"
+              class="btn btn-primary btn-sm shrink-0">
+              コピー
+            </button>
+          </div>
+          <p class="text-xs text-base-content/40">有効期限：<%= l(latest_invitation.expires_at, format: :short) %></p>
+        <% end %>
+
+        <!-- オーナーのみ招待リンク発行ボタンを表示 -->
+        <% if @family_group.user_family_groups.find_by(user: current_user)&.owner? %>
+          <%= form_with url: invitations_path, method: :post do |f| %>
+            <%= f.hidden_field :family_group_id, value: @family_group.id %>
+            <%= f.submit latest_invitation && !latest_invitation.expired? ? "再発行する" : "招待リンクを発行する",
+                  class: "btn btn-outline btn-sm w-full" %>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+
+    <!-- 操作ボタン -->
+    <div class="flex justify-between items-center">
+      <%= link_to mypage_path, class: "btn btn-ghost btn-sm gap-2" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18"/>
+        </svg>
+        マイページへ戻る
+      <% end %>
+
+      <% if @family_group.user_family_groups.find_by(user: current_user)&.owner? %>
+        <%= link_to family_group_path(@family_group),
+              data: { turbo_method: :delete, turbo_confirm: "グループを解散しますか？この操作は取り消せません。" },
+              class: "btn btn-error btn-outline btn-sm gap-2" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+          </svg>
+          グループを解散する
+        <% end %>
+      <% end %>
+    </div>
+
+  </div>
 </div>

--- a/app/views/family_groups/show.html.erb
+++ b/app/views/family_groups/show.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">FamilyGroups#show</h1>
+  <p>Find me in app/views/family_groups/show.html.erb</p>
+</div>

--- a/app/views/family_groups/show.html.erb
+++ b/app/views/family_groups/show.html.erb
@@ -42,40 +42,41 @@
       </div>
     </div>
 
-    <!-- 招待リンク (最新の招待リンクが存在し、かつ有効期限が切れていない場合) -->
-    <div class="card bg-base-100 shadow-2xl border border-base-200">
-      <div class="card-body p-6 gap-4">
-        <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60">招待リンク</span>
 
-        <% if @latest_invitation && !@latest_invitation.expired? %>
-          <div class="flex items-center gap-2" data-controller="clipboard">
-            <input
-              type="text"
-              readonly
-              value="<%= invitation_url(@latest_invitation.token) %>"
-              data-clipboard-target="source"
-              class="input input-bordered input-sm bg-base-200/50 w-full text-xs" />
-            <button
-              type="button"
-              data-clipboard-target="button"
-              data-action="click->clipboard#copy"
-              class="btn btn-primary btn-sm shrink-0">
-              コピー
-            </button>
-          </div>
-          <p class="text-xs text-base-content/40">有効期限：<%= l(@latest_invitation.expires_at, format: :short) %></p>
-        <% end %>
+    <% if @is_owner %>
+      <!-- オーナーのみ招待リンク発行ボタンを表示 -->
+      <div class="card bg-base-100 shadow-2xl border border-base-200">
+        <div class="card-body p-6 gap-4">
+          <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60">招待リンク</span>
 
-        <!-- オーナーのみ招待リンク発行ボタンを表示 -->
-        <% if @is_owner %>
+          <% if @latest_invitation && !@latest_invitation.expired? %>
+            <div class="flex items-center gap-2" data-controller="clipboard">
+              <input
+                type="text"
+                readonly
+                value="<%= invitation_url(@latest_invitation.token) %>"
+                data-clipboard-target="source"
+                class="input input-bordered input-sm bg-base-200/50 w-full text-xs" />
+              <button
+                type="button"
+                data-clipboard-target="button"
+                data-action="click->clipboard#copy"
+                class="btn btn-primary btn-sm shrink-0">
+                コピー
+              </button>
+            </div>
+            <p class="text-xs text-base-content/40">有効期限：<%= l(@latest_invitation.expires_at, format: :short) %></p>
+          <% end %>
+
+        <!-- 招待リンク (最新の招待リンクが存在し、かつ有効期限が切れていない場合) -->
           <%= form_with url: invitations_path, method: :post do |f| %>
             <%= f.hidden_field :family_group_id, value: @family_group.id %>
             <%= f.submit @latest_invitation && !@latest_invitation.expired? ? "再発行する" : "招待リンクを発行する",
                   class: "btn btn-outline btn-sm w-full" %>
           <% end %>
-        <% end %>
+        </div>
       </div>
-    </div>
+    <% end %>
 
     <!-- 操作ボタン -->
     <div class="flex justify-between items-center">

--- a/app/views/invitations/show.html.erb
+++ b/app/views/invitations/show.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">Invitations#show</h1>
+  <p>Find me in app/views/invitations/show.html.erb</p>
+</div>

--- a/app/views/invitations/show.html.erb
+++ b/app/views/invitations/show.html.erb
@@ -17,20 +17,20 @@
 
         <!-- テキスト -->
         <div class="flex flex-col gap-2">
-          <h1 class="text-xl font-bold tracking-tight">グループへの招待</h1>
+          <h1 class="text-xl font-bold tracking-tight"><%= t('invitation.show.title') %></h1>
           <p class="text-base-content/60 text-sm">
             <span class="font-semibold text-base-content"><%= @family_group.name %></span>
-            に招待されています
+              <%= t('invitation.show.invited_you') %>
           </p>
-          <p class="text-base-content/40 text-xs"><%= @family_group.users.count %>人が参加中</p>
+          <p class="text-base-content/40 text-xs"><%= t('invitation.show.people_joined', count: @family_group.users.count) %></p>
         </div>
 
         <!-- 参加ボタン -->
         <%= form_with url: join_invitation_path(@invitation.token), method: :post do |f| %>
-          <%= f.submit "参加する", class: "btn btn-primary w-full" %>
+          <%= f.submit t('invitation.show.join'), class: "btn btn-primary w-full" %>
         <% end %>
 
-        <%= link_to "参加しない", root_path, class: "btn btn-ghost btn-sm w-full" %>
+        <%= link_to t('invitation.show.not_join'), root_path, class: "btn btn-ghost btn-sm w-full" %>
 
       </div>
     </div>

--- a/app/views/invitations/show.html.erb
+++ b/app/views/invitations/show.html.erb
@@ -1,4 +1,38 @@
-<div>
-  <h1 class="font-bold text-4xl">Invitations#show</h1>
-  <p>Find me in app/views/invitations/show.html.erb</p>
+<div class="min-h-screen bg-base-200 flex justify-center items-center py-6 px-4">
+  <div class="fixed inset-0 overflow-hidden pointer-events-none">
+    <div class="absolute -top-24 -right-24 w-96 h-96 rounded-full opacity-10 bg-primary blur-3xl"></div>
+    <div class="absolute -bottom-24 -left-24 w-96 h-96 rounded-full opacity-10 bg-secondary blur-3xl"></div>
+  </div>
+
+  <div class="relative w-full max-w-md">
+    <div class="card bg-base-100 shadow-2xl border border-base-200">
+      <div class="card-body p-8 gap-6 items-center text-center">
+
+        <!-- アイコン -->
+        <div class="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-primary/10">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-8 h-8 text-primary">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z" />
+          </svg>
+        </div>
+
+        <!-- テキスト -->
+        <div class="flex flex-col gap-2">
+          <h1 class="text-xl font-bold tracking-tight">グループへの招待</h1>
+          <p class="text-base-content/60 text-sm">
+            <span class="font-semibold text-base-content"><%= @family_group.name %></span>
+            に招待されています
+          </p>
+          <p class="text-base-content/40 text-xs"><%= @family_group.users.count %>人が参加中</p>
+        </div>
+
+        <!-- 参加ボタン -->
+        <%= form_with url: join_invitation_path(@invitation.token), method: :post do |f| %>
+          <%= f.submit "参加する", class: "btn btn-primary w-full" %>
+        <% end %>
+
+        <%= link_to "参加しない", root_path, class: "btn btn-ghost btn-sm w-full" %>
+
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -91,7 +91,6 @@
           <p class="text-base-content/50 text-sm"><%= t('mypage.family_group.not_joined') %></p>
           <p class="text-base-content/40 text-xs"><%= t('mypage.family_group.not_joined_subtitle') %></p>
             <%= link_to t('mypage.family_group.create_group'), new_family_group_path, class: "btn btn-primary btn-sm px-6" %>
-          </div>
         </div>
       </div>
     <% end %>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -5,6 +5,7 @@
   </div>
 
   <div class="relative w-full max-w-2xl">
+    <!-- アカウントセクション -->
     <div class="flex items-center gap-3 mb-4">
       <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-primary/10 shrink-0">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-primary">
@@ -12,8 +13,8 @@
         </svg>
       </div>
       <div>
-        <h1 class="text-xl font-bold tracking-tight leading-tight"><%= t('mypage.title') %></h1>
-        <p class="text-base-content/50 text-xs"><%= t('mypage.subtitle') %></p>
+        <h1 class="text-xl font-bold tracking-tight leading-tight"><%= t('mypage.account_title') %></h1>
+        <p class="text-base-content/50 text-xs"><%= t('mypage.account_subtitle') %></p>
       </div>
     </div>
 
@@ -57,31 +58,29 @@
         </svg>
       </div>
       <div>
-        <h2 class="text-xl font-bold tracking-tight leading-tight">家族グループ</h2>
-        <p class="text-base-content/50 text-xs">グループを作成・管理できます</p>
+        <h2 class="text-xl font-bold tracking-tight leading-tight"><%= t('mypage.family_group.title') %></h2>
+        <p class="text-base-content/50 text-xs"><%= t('mypage.family_group.subtitle') %></p>
       </div>
     </div>
 
-    <% family_group = @user.family_groups.first %>
-    <% if family_group %>
+    <% if @family_group %>
       <!-- グループ参加済み -->
       <div class="card bg-base-100 shadow-2xl border border-base-200">
         <div class="card-body p-6 gap-4">
           <div class="flex items-center justify-between">
             <div>
-              <p class="font-semibold text-base"><%= family_group.name %></p>
-              <p class="text-base-content/50 text-xs mt-0.5"><%= family_group.users.count %>人のメンバー</p>
+              <p class="font-semibold text-base"><%= @family_group.name %></p>
+              <p class="text-base-content/50 text-xs mt-0.5"><%= t('mypage.family_group.member_count', count: @family_group.users.count) %></p>
             </div>
-            <% ufg = family_group.user_family_groups.find_by(user: @user) %>
-            <% if ufg&.owner? %>
-              <span class="badge badge-primary badge-sm">オーナー</span>
+            <% if @current_membership&.owner? %>
+              <span class="badge badge-primary badge-sm"><%= t('mypage.family_group.owner_badge') %></span>
             <% else %>
-              <span class="badge badge-ghost badge-sm">メンバー</span>
+              <span class="badge badge-ghost badge-sm"><%= t('mypage.family_group.member_badge') %></span>
             <% end %>
           </div>
 
           <div class="flex justify-end pt-1 border-t border-base-200">
-            <%= link_to "グループの詳細を見る", family_group_path(family_group), class: "btn btn-primary btn-sm px-6" %>
+            <%= link_to t('mypage.family_group.view_details'), family_group_path(@family_group), class: "btn btn-primary btn-sm px-6" %>
           </div>
         </div>
       </div>
@@ -89,10 +88,9 @@
       <!-- グループ未参加 -->
       <div class="card bg-base-100 shadow-2xl border border-base-200">
         <div class="card-body p-6 gap-4 items-center text-center">
-          <p class="text-base-content/50 text-sm">まだグループに参加していません</p>
-          <p class="text-base-content/40 text-xs">グループを作成するか、招待リンクから参加しましょう</p>
-          <div class="flex justify-center pt-1 border-t border-base-200 w-full">
-            <%= link_to "グループを作成する", new_family_group_path, class: "btn btn-primary btn-sm px-6" %>
+          <p class="text-base-content/50 text-sm"><%= t('mypage.family_group.not_joined') %></p>
+          <p class="text-base-content/40 text-xs"><%= t('mypage.family_group.not_joined_subtitle') %></p>
+            <%= link_to t('mypage.family_group.create_group'), new_family_group_path, class: "btn btn-primary btn-sm px-6" %>
           </div>
         </div>
       </div>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -48,5 +48,55 @@
         </div>
       </div>
     </div>
+
+    <!-- 家族グループセクション -->
+    <div class="flex items-center gap-3 mt-6 mb-4">
+      <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-primary/10 shrink-0">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-primary">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z" />
+        </svg>
+      </div>
+      <div>
+        <h2 class="text-xl font-bold tracking-tight leading-tight">家族グループ</h2>
+        <p class="text-base-content/50 text-xs">グループを作成・管理できます</p>
+      </div>
+    </div>
+
+    <% family_group = @user.family_groups.first %>
+    <% if family_group %>
+      <!-- グループ参加済み -->
+      <div class="card bg-base-100 shadow-2xl border border-base-200">
+        <div class="card-body p-6 gap-4">
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="font-semibold text-base"><%= family_group.name %></p>
+              <p class="text-base-content/50 text-xs mt-0.5"><%= family_group.users.count %>人のメンバー</p>
+            </div>
+            <% ufg = family_group.user_family_groups.find_by(user: @user) %>
+            <% if ufg&.owner? %>
+              <span class="badge badge-primary badge-sm">オーナー</span>
+            <% else %>
+              <span class="badge badge-ghost badge-sm">メンバー</span>
+            <% end %>
+          </div>
+
+          <div class="flex justify-end pt-1 border-t border-base-200">
+            <%= link_to "グループの詳細を見る", family_group_path(family_group), class: "btn btn-primary btn-sm px-6" %>
+          </div>
+        </div>
+      </div>
+    <% else %>
+      <!-- グループ未参加 -->
+      <div class="card bg-base-100 shadow-2xl border border-base-200">
+        <div class="card-body p-6 gap-4 items-center text-center">
+          <p class="text-base-content/50 text-sm">まだグループに参加していません</p>
+          <p class="text-base-content/40 text-xs">グループを作成するか、招待リンクから参加しましょう</p>
+          <div class="flex justify-center pt-1 border-t border-base-200 w-full">
+            <%= link_to "グループを作成する", new_family_group_path, class: "btn btn-primary btn-sm px-6" %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+
   </div>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -82,7 +82,8 @@ ja:
       new:
         title: 家族グループ新規作成
         subtitle: 家族グループを作成して、ミニメモリを共有しましょう
-        name_placeholder: グループ名を入力..."例：田中家、山田ファミリー"
+        name_label: グループ名
+        name_placeholder: グループ名を入力 (例：田中家、山田ファミリー)
         create_group: グループを作成
       show:
         invitation: 招待リンク

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -86,7 +86,19 @@ ja:
         create_group: グループを作成
       show:
         invitation: 招待リンク
-        
+        copy: コピー
+        invitation_expires_at: 有効期限
+        reissue_invitation: 再発行する
+        generate_invitation: 招待リンクを発行する
+        return_to_mypage: マイページに戻る
+        disband_group: グループを解散する
+  invitation:
+    show:
+      title: グループへの招待
+      invited_you: に招待されています
+      people_joined: "%{count}人が参加中"
+      join: 参加する
+      not_join: 参加しない
   header:
     mypage: マイページ
     user_create: 新規登録

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -23,6 +23,7 @@ ja:
       delete: 削除
       return_to_list: 一覧に戻る
       login: ログイン
+      cancel: キャンセル
     label:
       name: 名前
       email: メールアドレス
@@ -64,10 +65,28 @@ ja:
     show:
       return_to_list: 一覧に戻る
   mypage:
-    title: マイページ
-    subtitle: アカウント情報を確認できます
+    account_title: プロフィール
+    account_subtitle: アカウント情報を確認できます
     user_name: ユーザー名
     avatar: アバター画像
+    family_group:
+      title: 家族グループ
+      subtitle: グループを作成・管理できます
+      member_count: "%{count}人のメンバー"
+      owner_badge: オーナー
+      member_badge: メンバー
+      view_details: グループの詳細を見る
+      not_joined: グループに参加していません
+      not_joined_subtitle: 家族グループに参加して、ミニメモリを共有しましょう
+      create_group: グループを作成
+      new:
+        title: 家族グループ新規作成
+        subtitle: 家族グループを作成して、ミニメモリを共有しましょう
+        name_placeholder: グループ名を入力..."例：田中家、山田ファミリー"
+        create_group: グループを作成
+      show:
+        invitation: 招待リンク
+        
   header:
     mypage: マイページ
     user_create: 新規登録

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,8 +23,8 @@ Rails.application.routes.draw do
   # 掲示板 - uuidをURLパラメータとして使用するため、param: :uuidを指定
   resources :public_memories, param: :uuid, only: %i[index show]
 
-  # 家族グループ
-  resources :family_groups, only: %i[new create update show destroy]
+  # 家族グループ - uuidをURLパラメータとして使用するため、param: :uuidを指定
+  resources :family_groups, param: :uuid, only: %i[new create update show destroy]
 
   get "memory_game" => "memory_games#show", as: :memory_game
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,12 +23,20 @@ Rails.application.routes.draw do
   # 掲示板 - uuidをURLパラメータとして使用するため、param: :uuidを指定
   resources :public_memories, param: :uuid, only: %i[index show]
 
+  # 家族グループ
+  resources :family_groups, only: %i[new create update show destroy]
+
   get "memory_game" => "memory_games#show", as: :memory_game
 
   # ゲーム（写真で神経衰弱）
   namespace :api do
     resource :memory_game, only: %i[show]
   end
+
+  # 招待リンク
+  get  "invitations/:token",      to: "invitations#show",  as: :invitation
+  post "invitations/:token/join", to: "invitations#join",  as: :join_invitation
+  post "invitations",             to: "invitations#create", as: :invitations
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20260412145148_create_family_groups.rb
+++ b/db/migrate/20260412145148_create_family_groups.rb
@@ -1,0 +1,10 @@
+class CreateFamilyGroups < ActiveRecord::Migration[7.2]
+  def change
+    create_table :family_groups do |t|
+      t.string :name, null: false
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260412145148_create_family_groups.rb
+++ b/db/migrate/20260412145148_create_family_groups.rb
@@ -2,8 +2,6 @@ class CreateFamilyGroups < ActiveRecord::Migration[7.2]
   def change
     create_table :family_groups do |t|
       t.string :name, null: false
-      t.datetime :created_at, null: false
-      t.datetime :updated_at, null: false
       t.timestamps
     end
   end

--- a/db/migrate/20260412145726_create_user_family_groups.rb
+++ b/db/migrate/20260412145726_create_user_family_groups.rb
@@ -1,0 +1,13 @@
+class CreateUserFamilyGroups < ActiveRecord::Migration[7.2]
+  def change
+    create_table :user_family_groups do |t|
+      t.bigint "user_id", null: false
+      t.bigint "family_group_id", null: false
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.integer "role", default: 4, null: false
+      t.boolean "is_admin", default: false, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260412145726_create_user_family_groups.rb
+++ b/db/migrate/20260412145726_create_user_family_groups.rb
@@ -6,6 +6,6 @@ class CreateUserFamilyGroups < ActiveRecord::Migration[7.2]
       t.integer :role, null: false, default: 1  # 0: owner, 1: member
       t.timestamps
     end
-    add_index :user_family_groups, [:user_id, :family_group_id], unique: true
+    add_index :user_family_groups, [ :user_id, :family_group_id ], unique: true
   end
 end

--- a/db/migrate/20260412145726_create_user_family_groups.rb
+++ b/db/migrate/20260412145726_create_user_family_groups.rb
@@ -1,13 +1,11 @@
 class CreateUserFamilyGroups < ActiveRecord::Migration[7.2]
   def change
     create_table :user_family_groups do |t|
-      t.bigint "user_id", null: false
-      t.bigint "family_group_id", null: false
-      t.datetime "created_at", null: false
-      t.datetime "updated_at", null: false
-      t.integer "role", default: 4, null: false
-      t.boolean "is_admin", default: false, null: false
+      t.references :user, null: false, foreign_key: true
+      t.references :family_group, null: false, foreign_key: true
+      t.integer :role, null: false, default: 1  # 0: owner, 1: member
       t.timestamps
     end
+    add_index :user_family_groups, [:user_id, :family_group_id], unique: true
   end
 end

--- a/db/migrate/20260412145909_create_invitations.rb
+++ b/db/migrate/20260412145909_create_invitations.rb
@@ -1,7 +1,11 @@
 class CreateInvitations < ActiveRecord::Migration[7.2]
   def change
     create_table :invitations do |t|
+      t.references :family_group, null: false, foreign_key: true
+      t.string "token", null: false
+      t.datetime "expires_at", null: false
       t.timestamps
     end
+    add_index :invitations, :token, unique: true
   end
 end

--- a/db/migrate/20260412145909_create_invitations.rb
+++ b/db/migrate/20260412145909_create_invitations.rb
@@ -1,0 +1,7 @@
+class CreateInvitations < ActiveRecord::Migration[7.2]
+  def change
+    create_table :invitations do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260415144824_add_unique_index_to_user_family_groups_user_id.rb
+++ b/db/migrate/20260415144824_add_unique_index_to_user_family_groups_user_id.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToUserFamilyGroupsUserId < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :user_family_groups, :user_id
+    add_index :user_family_groups, :user_id, unique: true
+  end
+end

--- a/db/migrate/20260420145827_add_uuid_to_family_groups.rb
+++ b/db/migrate/20260420145827_add_uuid_to_family_groups.rb
@@ -1,5 +1,8 @@
 class AddUuidToFamilyGroups < ActiveRecord::Migration[7.2]
   def change
+    # PostgreSQLのuuid生成機能（pgcrypto）を有効化
+    enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')
+    # memoriesにuuidカラムを追加（レコード作成時に自動生成、nullを許可しない）
     add_column :family_groups, :uuid, :uuid, default: "gen_random_uuid()", null: false
     add_index :family_groups, :uuid, unique: true
   end

--- a/db/migrate/20260420145827_add_uuid_to_family_groups.rb
+++ b/db/migrate/20260420145827_add_uuid_to_family_groups.rb
@@ -1,0 +1,6 @@
+class AddUuidToFamilyGroups < ActiveRecord::Migration[7.2]
+  def change
+    add_column :family_groups, :uuid, :uuid, default: "gen_random_uuid()", null: false
+    add_index :family_groups, :uuid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_12_145909) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_15_144824) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -80,7 +80,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_12_145909) do
     t.datetime "updated_at", null: false
     t.index ["family_group_id"], name: "index_user_family_groups_on_family_group_id"
     t.index ["user_id", "family_group_id"], name: "index_user_family_groups_on_user_id_and_family_group_id", unique: true
-    t.index ["user_id"], name: "index_user_family_groups_on_user_id"
+    t.index ["user_id"], name: "index_user_family_groups_on_user_id", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_15_144824) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_20_145827) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -47,6 +47,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_15_144824) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.index ["uuid"], name: "index_family_groups_on_uuid", unique: true
   end
 
   create_table "invitations", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_15_094956) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_12_145909) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -43,6 +43,22 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_15_094956) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "family_groups", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "invitations", force: :cascade do |t|
+    t.bigint "family_group_id", null: false
+    t.string "token", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["family_group_id"], name: "index_invitations_on_family_group_id"
+    t.index ["token"], name: "index_invitations_on_token", unique: true
+  end
+
   create_table "memories", force: :cascade do |t|
     t.string "title", null: false
     t.text "description", null: false
@@ -54,6 +70,17 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_15_094956) do
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.index ["user_id"], name: "index_memories_on_user_id"
     t.index ["uuid"], name: "index_memories_on_uuid", unique: true
+  end
+
+  create_table "user_family_groups", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "family_group_id", null: false
+    t.integer "role", default: 1, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["family_group_id"], name: "index_user_family_groups_on_family_group_id"
+    t.index ["user_id", "family_group_id"], name: "index_user_family_groups_on_user_id_and_family_group_id", unique: true
+    t.index ["user_id"], name: "index_user_family_groups_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -74,5 +101,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_15_094956) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "invitations", "family_groups"
   add_foreign_key "memories", "users"
+  add_foreign_key "user_family_groups", "family_groups"
+  add_foreign_key "user_family_groups", "users"
 end

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -2,14 +2,4 @@ require "test_helper"
 
 class DashboardControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
-
-  setup do
-    @user = users(:one)
-    sign_in @user
-  end
-
-  test "should get top" do
-    get authenticated_root_path
-    assert_response :success
-  end
 end

--- a/test/controllers/family_groups_controller_test.rb
+++ b/test/controllers/family_groups_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class FamilyGroupsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get family_groups_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get family_groups_create_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get family_groups_show_url
+    assert_response :success
+  end
+
+  test "should get destroy" do
+    get family_groups_destroy_url
+    assert_response :success
+  end
+end

--- a/test/controllers/family_groups_controller_test.rb
+++ b/test/controllers/family_groups_controller_test.rb
@@ -1,23 +1,4 @@
 require "test_helper"
 
 class FamilyGroupsControllerTest < ActionDispatch::IntegrationTest
-  test "should get new" do
-    get family_groups_new_url
-    assert_response :success
-  end
-
-  test "should get create" do
-    get family_groups_create_url
-    assert_response :success
-  end
-
-  test "should get show" do
-    get family_groups_show_url
-    assert_response :success
-  end
-
-  test "should get destroy" do
-    get family_groups_destroy_url
-    assert_response :success
-  end
 end

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -1,23 +1,4 @@
 require "test_helper"
 
 class InvitationsControllerTest < ActionDispatch::IntegrationTest
-  test "should get new" do
-    get invitations_new_url
-    assert_response :success
-  end
-
-  test "should get create" do
-    get invitations_create_url
-    assert_response :success
-  end
-
-  test "should get show" do
-    get invitations_show_url
-    assert_response :success
-  end
-
-  test "should get join" do
-    get invitations_join_url
-    assert_response :success
-  end
 end

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class InvitationsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get invitations_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get invitations_create_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get invitations_show_url
+    assert_response :success
+  end
+
+  test "should get join" do
+    get invitations_join_url
+    assert_response :success
+  end
+end

--- a/test/controllers/mypages_controller_test.rb
+++ b/test/controllers/mypages_controller_test.rb
@@ -1,13 +1,4 @@
 require "test_helper"
 
 class MypagesControllerTest < ActionDispatch::IntegrationTest
-  setup do
-    @user = users(:one) # fixtures
-    sign_in @user
-  end
-
-  test "should get show" do
-    get mypage_url
-    assert_response :success
-  end
 end

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -1,8 +1,4 @@
 require "test_helper"
 
 class StaticPagesControllerTest < ActionDispatch::IntegrationTest
-  test "should get top" do
-    get root_path
-    assert_response :success
-  end
 end

--- a/test/fixtures/family_groups.yml
+++ b/test/fixtures/family_groups.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/family_groups.yml
+++ b/test/fixtures/family_groups.yml
@@ -4,8 +4,10 @@
 # model remove the "{}" from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-one: {}
+one:
+  name: "テスト家族１"
 # column: value
 #
-two: {}
+two:
+  name: "テスト家族２"
 # column: value

--- a/test/fixtures/invitations.yml
+++ b/test/fixtures/invitations.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/invitations.yml
+++ b/test/fixtures/invitations.yml
@@ -4,8 +4,14 @@
 # model remove the "{}" from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-one: {}
+one:
+  family_group: one
+  token: "invite-token-one"
+  expires_at: <%= 1.day.from_now %>
 # column: value
 #
-two: {}
+two:
+  family_group: two
+  token: "invite-token-two"
+  expires_at: <%= 2.days.from_now %>
 # column: value

--- a/test/fixtures/user_family_groups.yml
+++ b/test/fixtures/user_family_groups.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/user_family_groups.yml
+++ b/test/fixtures/user_family_groups.yml
@@ -4,8 +4,14 @@
 # model remove the "{}" from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-one: {}
+one:
+  user: one
+  family_group: one
+  role: member
 # column: value
 #
-two: {}
+two:
+  user: two
+  family_group: two
+  role: member
 # column: value

--- a/test/models/family_group_test.rb
+++ b/test/models/family_group_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FamilyGroupTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/invitation_test.rb
+++ b/test/models/invitation_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class InvitationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/user_family_group_test.rb
+++ b/test/models/user_family_group_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserFamilyGroupTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
家族グループ機能を追加した。
ユーザーが家族グループを作成し、招待リンクを発行し、招待されたユーザーがグループに参加できるようにした。
あわせて、マイページから家族グループの状態確認と詳細画面への導線も追加した。

## 変更内容
- `FamilyGroup` / `UserFamilyGroup` / `Invitation` モデルを追加
- 家族グループ作成時に、作成者をオーナーとして紐づける処理を追加
- 家族グループ詳細画面を追加
- 招待リンク発行機能を追加
- 招待リンク経由での参加機能を追加
- 招待リンク表示画面を追加
- マイページに家族グループ表示エリアを追加
- 招待リンクをコピーできる Stimulus の `clipboard_controller` を追加
- 家族グループURLで `uuid` を利用するように変更
- ログイン後、招待リンクへ戻れるように `stored_location_for` を利用した遷移に変更

## 画面/挙動
- マイページ
  - 家族グループ未参加の場合は「グループを作成」を表示
  - 参加済みの場合はグループ名、人数、権限、詳細導線を表示
- 家族グループ詳細
  - メンバー一覧を表示
  - オーナーのみ招待リンク発行/再発行が可能
  - 有効な最新招待リンクを表示し、コピー可能
  - オーナーのみグループ削除可能
- 招待リンク
  - 未ログイン時はログインへ誘導
  - ログイン後は招待ページへ復帰
  - 参加時はメンバー権限でグループに所属

## DB変更
- `family_groups` テーブル追加
- `user_family_groups` テーブル追加
- `invitations` テーブル追加
- `family_groups.uuid` を追加
- `user_family_groups.user_id` に一意制約を追加
  - 1ユーザーは1つの家族グループのみ所属可能

## 補足
- 招待リンクには有効期限を設定
- 既に家族グループに所属しているユーザーは招待リンクから参加不可


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ファミリーグループの作成・表示・編集・解散が可能になりました
  * 招待リンクの発行・閲覧・参加フローを追加しました（有効期限・再発行対応）
  * 招待リンクのワンクリックコピーとコピー成功/失敗のフィードバックを追加しました

* **その他の改善**
  * マイページにファミリーグループ情報と役割（オーナー/メンバー）表示を追加しました
  * ログイン後は招待などの元のページへ戻るリダイレクトを優先するようになりました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->