### PR TITLE
Pundit を導入し認可基盤を整備

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,9 @@ gem "cloudinary"
 # meta-tags - メタタグ管理
 gem "meta-tags"
 
+# Pundit - 認可（Policy ベース）
+gem "pundit"
+
 group :development, :test do
   # debug - デバッグツール
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,6 +264,8 @@ GEM
     public_suffix (7.0.0)
     puma (7.2.0)
       nio4r (~> 2.0)
+    pundit (2.5.2)
+      activesupport (>= 3.0.0)
     racc (1.8.1)
     rack (3.2.4)
     rack-protection (4.2.1)
@@ -448,6 +450,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection
   pg (~> 1.1)
   puma (>= 5.0)
+  pundit
   rails (~> 7.2.2)
   rails-i18n
   rubocop-rails-omakase

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,14 @@
 class ApplicationController < ActionController::Base
+  include Pundit::Authorization
+
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!, unless: :devise_controller?
+
+  # Pundit::NotAuthorizedError を捕捉し、flash + 元のページへ戻すハンドリング。
+  # verify_authorized は意図的に有効化していない（既存コントローラへの段階導入のため）。
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   protected
 
@@ -10,5 +16,12 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
     devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
+  end
+
+  private
+
+  def user_not_authorized
+    flash[:alert] = t("pundit.not_authorized")
+    redirect_back fallback_location: root_path
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,35 @@
+# Pundit Policy の基底クラス。
+# 各リソースの Policy はこのクラスを継承し、`#index?` や `#update?` などの述語メソッドで
+# 認可ルールを宣言する。controller 側では `authorize @record` を呼ぶことで
+# 対応する Policy のメソッドが呼ばれ、false を返すと Pundit::NotAuthorizedError が発生する。
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?     = false
+  def show?      = false
+  def create?    = false
+  def new?       = create?
+  def update?    = false
+  def edit?      = update?
+  def destroy?   = false
+
+  # index アクションでログインユーザーが閲覧可能なレコード集合を返す Scope。
+  # `policy_scope(Model)` を controller で呼ぶと `Scope.new(current_user, Model).resolve` が走る。
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      raise NoMethodError, "You must define #resolve in #{self.class}"
+    end
+  end
+end

--- a/config/locales/pundit.ja.yml
+++ b/config/locales/pundit.ja.yml
@@ -1,0 +1,3 @@
+ja:
+  pundit:
+    not_authorized: 操作する権限がありません


### PR DESCRIPTION
## 概要
  - Pundit gem を導入し、Policy ベースの認可基盤を構築                                                                                                                                                                                         
  - `ApplicationController` に `Pundit::Authorization` を include し、`Pundit::NotAuthorizedError` を `rescue_from` で捕捉
  - 共通の基底クラス `ApplicationPolicy` を追加（各リソースの Policy はこれを継承）                                                                                                                                                            
  - 未認可メッセージを I18n 化（`config/locales/pundit.ja.yml`）                                                                                                                                                                               
                                                                                                                                                                                                                                               
 ## 変更ファイル一覧                                                                                                                                                                                                                          
  | ファイル | 種別 | 変更理由 |                                                                            
  |---------|------|---------|                                                                                                                                                                                                                 
  | `Gemfile` / `Gemfile.lock` | 変更 | `pundit` gem を追加 |                                                                                                                                                                                  
  | `app/controllers/application_controller.rb` | 変更 | `Pundit::Authorization` を include / `NotAuthorizedError` のハンドリング追加 |
  | `app/policies/application_policy.rb` | 新規 | 全 Policy が継承する基底クラス |                                                                                                                                                             
  | `config/locales/pundit.ja.yml` | 新規 | 未認可時の flash メッセージを日本語化 |                                                                                                                                                            
                                                                                                                                                                                                                                               
  ## 実装のポイント                                                                                                                                                                                                                            
  - `verify_authorized` / `verify_policy_scoped` は **意図的に未有効化**。既存コントローラへの段階導入のため、後続 PR で対象コントローラから順次 `authorize` / `policy_scope` を導入していく方針。                                             
  - `NotAuthorizedError` 発生時は `redirect_back fallback_location: root_path` で元ページへ戻す。fallback により直アクセス時も安全に処理。                                                                                                     
  - メッセージは I18n 経由（`t("pundit.not_authorized")`）で取得。                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
  ## 残件・TODO                                                                                                                                                                                                                                
  - 各リソース（`Memory` / `FamilyGroup` / `UserFamilyGroup` 等）の Policy 実装を別 PR で対応予定             
  - 段階導入が完了したら `verify_authorized` の有効化を検討                                                            

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ユーザーの操作権限を管理する認可システムを導入しました。
  * 認可されていないアクションへのアクセス時に、日本語のエラーメッセージが表示されるようになりました。前のページに自動的にリダイレクトされます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->