### PR TITLE
各リソースの Policy + Scope を追加（コントローラ適用なし）

### DIFF
--- a/app/policies/family_group_policy.rb
+++ b/app/policies/family_group_policy.rb
@@ -1,0 +1,29 @@
+# FamilyGroup に対する認可ルール。
+# 1 ユーザー 1 グループ制約があるため、create? は未所属ユーザーのみ許可する。
+class FamilyGroupPolicy < ApplicationPolicy
+  def index?   = user.present?
+  def show?    = member?
+  def create?  = user.present? && user.user_family_groups.empty?
+  def update?  = owner?
+  def destroy? = owner?
+
+  # 自分が所属しているグループのみ可視。
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope.none if user.nil?
+      scope.joins(:user_family_groups).where(user_family_groups: { user_id: user.id })
+    end
+  end
+
+  private
+
+  def member?
+    return false if user.nil?
+    record.user_family_groups.exists?(user_id: user.id)
+  end
+
+  def owner?
+    return false if user.nil?
+    record.user_family_groups.exists?(user_id: user.id, role: :owner)
+  end
+end

--- a/app/policies/invitation_policy.rb
+++ b/app/policies/invitation_policy.rb
@@ -1,0 +1,26 @@
+# Invitation（家族グループへの招待リンク）に対する認可ルール。
+# 招待リンクの発行・閲覧・削除はグループの owner のみ可能。
+# 招待トークン経由の受諾フローは未認証ユーザーでも辿れるが、その経路は
+# Pundit を経由せず、コントローラ側で token 検証で代替する想定。
+class InvitationPolicy < ApplicationPolicy
+  def index?   = group_owner?
+  def show?    = group_owner?
+  def create?  = group_owner?
+  def destroy? = group_owner?
+
+  # 自分が owner であるグループの招待のみ可視。
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope.none if user.nil?
+      owned_group_ids = UserFamilyGroup.where(user_id: user.id, role: :owner).select(:family_group_id)
+      scope.where(family_group_id: owned_group_ids)
+    end
+  end
+
+  private
+
+  def group_owner?
+    return false if user.nil?
+    UserFamilyGroup.exists?(family_group_id: record.family_group_id, user_id: user.id, role: :owner)
+  end
+end

--- a/app/policies/memory_policy.rb
+++ b/app/policies/memory_policy.rb
@@ -1,0 +1,26 @@
+# Memory に対する認可ルール。
+# 公開済み (published) 投稿は所有者以外も閲覧可能、それ以外は所有者のみ操作可能。
+#
+# Scope は MemoriesController（認証必須・自分の投稿一覧）向けに「自分の投稿のみ」を返す。
+# PublicMemoriesController は公開情報を扱うため Pundit を経由しない設計（Memory.publicly_available を直接使用）。
+class MemoryPolicy < ApplicationPolicy
+  def index?   = true
+  def show?    = record.published? || owner?
+  def create?  = user.present?
+  def update?  = owner?
+  def destroy? = owner?
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope.none if user.nil?
+      scope.where(user: user)
+    end
+  end
+
+  private
+
+  def owner?
+    return false if user.nil?
+    record.user_id == user.id
+  end
+end

--- a/app/policies/user_family_group_policy.rb
+++ b/app/policies/user_family_group_policy.rb
@@ -1,0 +1,33 @@
+# UserFamilyGroup（グループメンバーシップ）に対する認可ルール。
+# 招待経由の自己参加 / 自己脱退と、owner による他メンバー管理を許可する。
+class UserFamilyGroupPolicy < ApplicationPolicy
+  def show?    = same_group_member?
+  def create?  = user.present? && record.user_id == user.id
+  def update?  = group_owner?
+  def destroy? = self_membership? || group_owner?
+
+  # 自分が属するグループのメンバーシップのみ可視。
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope.none if user.nil?
+      scope.where(family_group_id: user.family_groups.select(:id))
+    end
+  end
+
+  private
+
+  def same_group_member?
+    return false if user.nil?
+    user.family_groups.exists?(id: record.family_group_id)
+  end
+
+  def self_membership?
+    return false if user.nil?
+    record.user_id == user.id
+  end
+
+  def group_owner?
+    return false if user.nil?
+    UserFamilyGroup.exists?(family_group_id: record.family_group_id, user_id: user.id, role: :owner)
+  end
+end


### PR DESCRIPTION
 ## 概要                                                                                                                                                                                                                                    
  - Memory / FamilyGroup / UserFamilyGroup / Invitation の Policy + Scope を追加                                                                                                                                                               
  - 段階導入のため、本 PR では `authorize` / `policy_scope` の呼び出しは入れず、Policy クラスの定義のみ                                                                                                                                      
  - テストは Pundit 全体の実装が完了したタイミングで RSpec セットアップと併せてまとめて追加予定                                                                                                                                                
                                                                                                                                                                                                                                               
  ## 関連 Issue                                                                                                                                                                                                                                
  （Pundit 段階導入の 2 段目。続いて各コントローラへの適用 PR を分割予定）                                                                                                                                                                     
                                                                                                                                                                                                                                               
  ## 変更ファイル一覧                                                                                                                                                                                                                          
  | ファイル | 種別 | 変更理由 |                                                                                                                                                                                                               
  |---------|------|---------|                                                                                                                                                                                                                 
  | `app/policies/memory_policy.rb` | 新規 | Memory の認可ルール |                                                                                                                                                                             
  | `app/policies/family_group_policy.rb` | 新規 | FamilyGroup の認可ルール |                                                                                                                                                                
  | `app/policies/user_family_group_policy.rb` | 新規 | グループメンバーシップの認可ルール |                                                                                                                                                   
  | `app/policies/invitation_policy.rb` | 新規 | 招待リンクの認可ルール |                                                                                                                                                                      
                                                                                                                                                                                                                                               
  ## 実装のポイント                                                                                                                                                                                                                            
  ### MemoryPolicy                                                                                                                                                                                                                             
  - `show?` は「公開済みなら誰でも、それ以外は所有者」                                                                                                                                                                                       
  - `Scope` は **MemoriesController（自分の投稿一覧）向けに自分の投稿のみ** を返す                                                                                                                                                             
  - `PublicMemoriesController` は公開情報を扱うため **Pundit を経由しない設計**（既存の `Memory.publicly_available` を直接使用）。これにより既存の責務分離（自分の投稿 vs 公開投稿）と一致                                                     
                                                                                                                                                                                                                                               
  ### FamilyGroupPolicy                                                                                                                                                                                                                        
  - 1 ユーザー 1 グループ制約があるため `create?` は **未所属ユーザーのみ** 許可                                                                                                                                                               
  - `show?` は所属メンバー、`update?` / `destroy?` は owner のみ                                                                                                                                                                               
  - Scope は自分が所属するグループに限定                                                                                                                                                                                                       
                                                                                                                                                                                                                                               
  ### UserFamilyGroupPolicy                                                                                                                                                                                                                    
  - `create?` は招待経由の **自己参加のみ** （`record.user_id == user.id`）を許可                                                                                                                                                              
  - `destroy?` は **自己脱退 OR owner による他メンバー除名** を許可                                                                                                                                                                            
  - Scope は自分が属するグループのメンバーシップに限定                                                                                                                                                                                         
                                                                                                                                                                                                                                               
  ### InvitationPolicy                                                                                                                                                                                                                         
  - 全アクション owner のみ可能                                                                                                                                                                                                                
  - 招待トークン経由の受諾フローは未認証ユーザーでも辿れる必要があるため **Pundit を経由しない**（コントローラ側の token 検証で代替する想定）                                                                                                  
                                                                                                                                                                                                                                             
  ## 残件・TODO                                                                                                                                                                                                                                
  - 各コントローラへの `authorize` / `policy_scope` 適用（リソースごとに別 PR に分割予定）                                                                                                                                                                                                                                                                                                                               
  - 段階導入完了後に `verify_authorized` / `verify_policy_scoped` の有効化を検討

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **セキュリティ改善**
  * ファミリーグループのアクセス権限制御を強化しました。ユーザーは自身が属するグループのみ表示・管理できます
  * メモリー（思い出）の表示権限を設定しました。公開されているメモリーと自身が作成したメモリーのみ閲覧可能です
  * ファミリーグループへの招待機能に権限チェックを追加し、グループ管理者のみ招待リンクを管理できます

<!-- end of auto-generated comment: release notes by coderabbit.ai -->