### PR TITLE
 MemoriesController に Pundit を適用

### DIFF
--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -1,16 +1,19 @@
 class MemoriesController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_memory, only: %i[show edit update destroy]
 
   def index
-    @my_memories = current_user.memories.with_attached_image.order(created_at: :desc)
+    @my_memories = policy_scope(Memory).with_attached_image.order(created_at: :desc)
   end
 
   def new
     @memory = Memory.new
+    authorize @memory
   end
 
   def create
     @memory = current_user.memories.build(memory_params)
+    authorize @memory
 
     begin
       if params[:memory][:image].present?
@@ -33,12 +36,9 @@ class MemoriesController < ApplicationController
   end
 
   def edit
-    @memory = current_user.memories.find_by!(uuid: params[:uuid])
   end
 
   def update
-    @memory = current_user.memories.find_by!(uuid: params[:uuid])
-
     begin
       @memory.assign_attributes(memory_params.except(:image))
       # 画像がアップロードされている場合のみ画像処理を実行
@@ -62,18 +62,19 @@ class MemoriesController < ApplicationController
   end
 
   def destroy
-    memory = current_user.memories.find_by!(uuid: params[:uuid])
-    memory.destroy!
+    @memory.destroy!
     redirect_to memories_path, notice: t("defaults.flash_message.deleted", model: Memory.model_name.human)
   end
 
-
-
   def show
-    @memory = current_user.memories.find_by!(uuid: params[:uuid])
   end
 
   private
+
+  def set_memory
+    @memory = Memory.find_by!(uuid: params[:uuid])
+    authorize @memory
+  end
 
   def memory_params
     params.require(:memory).permit(:title, :description, :memory_date, :visibility, :image)


### PR DESCRIPTION
## 概要                                                                                                                                                                                                                                      
  - `MemoriesController` に Pundit を適用し、`current_user.memories` による暗黙の認可ロジックを Policy ベースに置き換え
  - `index` を `policy_scope(Memory)` 経由に変更                                                                                                                                                                                               
  - `show` / `edit` / `update` / `destroy` を `set_memory` コールバックで `Memory.find_by!(uuid:)` + `authorize @memory` に統一                                                                                                                
  - `new` / `create` で `authorize @memory` を呼び出し                                                                                                                                                                                         
  - `PublicMemoriesController` は公開情報を扱うため本 PR では変更せず（Pundit 非経由設計を維持）                                                                                                                                               
                                                                                                                                                                                                                                               
  ## 関連 Issue                                                                                                                                                                                                                                
  （Pundit 段階導入の 3 段目。続いて FamilyGroup / Invitation のコントローラ適用 PR を予定）                                                                                                                                                   
                                                                                                                                                                                                                                               
  ## 変更ファイル一覧                                                                                                                                                                                                                          
  | ファイル | 種別 | 変更理由 |                                                                               
  |---------|------|---------|                                                                                                                                                                                                                 
  | `app/controllers/memories_controller.rb` | 変更 | Pundit の `policy_scope` / `authorize` を適用 |          
                                                                                                     
  ## 実装のポイント                                                                                                                                                                                                                            
  ### 取得 + 認可を `set_memory` に集約
  `show` / `edit` / `update` / `destroy` で重複していた `current_user.memories.find_by!(uuid:)` を、`set_memory` コールバックの `Memory.find_by!(uuid:)` + `authorize @memory` に置き換え。認可呼び出しの記述漏れを防げる。                    
                                                                                                                                                                                                                                               
  ### 他人の memory への直アクセス時の UX 変化                                                                                                                                                                                                 
  - **Before:** `current_user.memories.find_by!` で `ActiveRecord::RecordNotFound`（404 / 存在を隠す）                                                                                                                                         
  - **After:** `Memory.find_by!` + `authorize` で `Pundit::NotAuthorizedError`（前 PR の `rescue_from` で flash + `redirect_back`）                                                                                                            
                                                                                                                                                                                                                                               
  公開済み投稿の存在は `PublicMemoriesController` 経由で公開されているため、403 相当に変わっても情報漏洩リスクは増えない。一方、private_only の存在を隠したい場合は将来 `policy_scope` ベースの取得に切り替える余地あり（今回は                
  `MemoryPolicy#show?` が「公開済みなら誰でも閲覧可」というロジックを保持できるよう、あえて `find_by!` を採用）。                                                                                                                              
                                                                                                                                                                                                                                               
  ### `PublicMemoriesController` は不変                                                                                                                                                                                                        
  公開情報の閲覧は認可判定不要のため、Pundit を経由しない既存設計を維持。                                                                                                                                                                                                   
                                                                                                                                                                                                                                               
  ## 残件・TODO                                                                                                                                                                                                                                
  - `FamilyGroupsController` への Pundit 適用                                                                                                                                                                                   
  - `InvitationsController` への Pundit 適用                                                                                                                                                                                        
  - 全コントローラ適用完了後に `verify_authorized` / `verify_policy_scoped` の有効化を検討                                                                                                                                                     