### PR TITLE
FamilyGroupsController に Pundit を適用

### DIFF
--- a/app/controllers/family_groups_controller.rb
+++ b/app/controllers/family_groups_controller.rb
@@ -4,10 +4,12 @@ class FamilyGroupsController < ApplicationController
 
   def new
     @family_group = FamilyGroup.new
+    authorize @family_group
   end
 
   def create
     @family_group = FamilyGroup.new(family_group_params)
+    authorize @family_group
 
     # グループ作成とオーナー登録をトランザクションでまとめる
     ActiveRecord::Base.transaction do
@@ -20,7 +22,7 @@ class FamilyGroupsController < ApplicationController
   rescue ActiveRecord::RecordInvalid
     flash.now[:alert] = "家族グループの作成に失敗しました"
     render :new, status: :unprocessable_entity
-  rescue ActiveRecord::RecordNotUnique # ユーザーが既にグループに所属している場合の例外
+  rescue ActiveRecord::RecordNotUnique # race condition 等の防御的フォールバック
     redirect_to mypage_path, alert: "既に家族グループに所属しています"
   end
 
@@ -46,15 +48,10 @@ class FamilyGroupsController < ApplicationController
   end
 
   def destroy
-    # オーナーのみグループ削除可能
-    if @family_group.user_family_groups.find_by(user: current_user)&.owner?
-      if @family_group.destroy
-        redirect_to mypage_path, notice: "家族グループが削除されました"
-      else
-        redirect_to @family_group, alert: "家族グループの削除に失敗しました"
-      end
+    if @family_group.destroy
+      redirect_to mypage_path, notice: "家族グループが削除されました"
     else
-      redirect_to @family_group, alert: "家族グループの削除はオーナーのみ可能です"
+      redirect_to @family_group, alert: "家族グループの削除に失敗しました"
     end
   end
 
@@ -64,7 +61,9 @@ class FamilyGroupsController < ApplicationController
     params.require(:family_group).permit(:name)
   end
 
+  # 非メンバーには 404（存在を隠す）、メンバー以上には authorize で操作種別を判定する二段防衛。
   def set_family_group
-    @family_group = current_user.family_groups.find_by!(uuid: params[:uuid])
+    @family_group = policy_scope(FamilyGroup).find_by!(uuid: params[:uuid])
+    authorize @family_group
   end
 end


### PR DESCRIPTION
## 概要
  - `FamilyGroupsController` に Pundit を適用し、`current_user.family_groups` による認可と `destroy` 内のインライン owner チェックを Policy ベースに置き換え
  - `set_family_group` で `policy_scope(FamilyGroup)` + `authorize @family_group` の二段防衛を採用
  - `new` / `create` で `authorize @family_group` を呼び、1 ユーザー 1 グループ制約を早期適用


  ## 変更ファイル一覧
  | ファイル | 種別 | 変更理由 |
  |---------|------|---------|
  | `app/controllers/family_groups_controller.rb` | 変更 | Pundit の `policy_scope` / `authorize` を適用 |
                                                                                               
  ## テスト計画                                                                                                                                                                                                                                   
                                                                                                                 
  - [x] ローカル動作確認                                                                                                                                                                                                                           
    - owner で show / update / destroy（従来通り動作）
    - member（非 owner）の show 表示（@is_owner = false）                                                                                                                                                                                      
    - member（非 owner）の destroy → Rails console で FamilyGroupPolicy#destroy? が false を返すことを確認                                                                                                                                     
    - 非メンバーの uuid 直叩き → 404                                                                                                                                                                                                           
    - 未所属ユーザーの /new → 通常作成可                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                               
 ##  残件・TODO                                                                                                                                                                                                                                                                                                                                                                                                                                                           
  - InvitationsController への Pundit 適用                                                                                                                                                                 
  - 全コントローラ適用完了後に verify_authorized / verify_policy_scoped の有効化を検討                           
  - メッセージの細かい最適化（destroy 等のドメイン特化文言）も併せて検討                                                                                                                                                                       

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ファミリーグループの重複作成時のエラーハンドリングを改善し、わかりやすいメッセージを表示するようになりました。

* **セキュリティ改善**
  * ファミリーグループへのアクセス権限チェックをより厳密に実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->