### PR TITLE
InvitationsController に Pundit を適用

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -38,7 +38,7 @@ class InvitationsController < ApplicationController
 
     # 招待リンクの有効性と期限切れのチェック
     if @invitation.nil? || @invitation.expired?
-      redirect_to root_path, alert: "招待リンクが無効または期限切れです"
+      return redirect_to root_path, alert: "招待リンクが無効または期限切れです"
     end
 
     # ログインしていない場合はURLを保存し、ログインページへリダイレクト

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -23,7 +23,7 @@ class InvitationsController < ApplicationController
   def join
     @family_group = @invitation.family_group
     membership = UserFamilyGroup.new(user: current_user, family_group: @family_group, role: :member)
-    authorize membership
+    authorize membership, :create?
     membership.save!
     redirect_to mypage_path, notice: "#{@family_group.name}に参加しました"
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -5,25 +5,26 @@ class InvitationsController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[show]
   before_action :set_and_validate_invitation, only: %i[show join]
 
-  # 招待リンクの発行(サーバー側でもう一度オーナーであることを確認)
+  # 招待リンクの発行（owner であることは InvitationPolicy#create? で検証）
   def create
-    membership = current_user.user_family_groups.find_by!(
-      family_group_id: params[:family_group_id],
-      role: :owner
-      )
-    family_group = membership.family_group
-    family_group.invitations.create!
-    redirect_to family_group, notice: "招待リンクが発行されました"
+    @invitation = Invitation.new(family_group_id: params[:family_group_id])
+    authorize @invitation
+    @invitation.save!
+    redirect_to @invitation.family_group, notice: "招待リンクが発行されました"
   end
 
   def show
     @family_group = @invitation.family_group
   end
 
-  # 招待リンクを踏んで参加するアクション
+  # 招待リンクを踏んで参加するアクション。
+  # トークン検証は set_and_validate_invitation で済むが、authorize で
+  # UserFamilyGroupPolicy#create? も通すことで verify_authorized 有効化時に対応できる構成にしておく。
   def join
     @family_group = @invitation.family_group
-    UserFamilyGroup.create!(user: current_user, family_group: @family_group, role: :member) # メンバー権限として参加
+    membership = UserFamilyGroup.new(user: current_user, family_group: @family_group, role: :member)
+    authorize membership
+    membership.save!
     redirect_to mypage_path, notice: "#{@family_group.name}に参加しました"
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
     redirect_to invitation_path(params[:token]), alert: "グループへの参加に失敗しました"


### PR DESCRIPTION
## 概要                                                         
  - `InvitationsController` に Pundit を適用し、招待発行時の owner check と参加時のメンバーシップ作成を Policy ベースに置き換え                                                                                                                
  - `show` は未認証アクセスを許す唯一の動線のため Pundit 非経由を維持（トークン検証で代替）                                                                                                                                                  
  - 動作確認中に発覚した既存の `set_and_validate_invitation` の return 漏れによる DoubleRenderError も同 PR で修正                                                                                                                             
                                                                                                                                                                                                                                               
  ## 関連 Issue                                                                                                                                                                                                                                
  （Pundit 段階導入の最終段。これでコントローラ適用が一巡）                                                                                                                                                                                    
                                                                                                                                                                                                                                               
  ## 変更ファイル一覧                                                                                                                                                                                                                          
  | ファイル | 種別 | 変更理由 |                                                                                                                                                                                                               
  |---------|------|---------|                                                                                                                                                                                                                 
  | `app/controllers/invitations_controller.rb` | 変更 | Pundit の `authorize` を適用 + 既存バグ（return 漏れ）修正 |                                                                                                                          
                                                                                                                     
  ## コミット                                                                                                                                                                                                                                  
  1. `feat: InvitationsController に Pundit を適用` — `create` / `join` への authorize 適用
  2. `fix: join アクションでの authorize に Policy メソッド名を明示` — `:create?` を明示（後述）                                                                                                                                               
  3. `fix: set_and_validate_invitation の redirect_to に return を追加` — DoubleRenderError 修正

## テスト計画                                                                                                     
                                                                  
  - [x]  ローカル動作確認                                                                                                                                                                                                                           
    - owner として招待リンク発行（成功）
    - 未所属ユーザーの参加 POST                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
    - 招待 URL に未ログインで GET（ログインページへリダイレクト）                                                                                                                                                                              
    - 既所属ユーザーが招待 URL を GET（mypage へリダイレクト）                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                               
##  残件・TODO                                                                                                                                                                                                                                                                                                                                                                   
  - 全コントローラ適用完了後に verify_authorized / verify_policy_scoped の有効化を検討                           
  - 段階導入完了後に汎用「操作する権限がありません」をアクション固有メッセージへ最適化検討                                                                                                                                                     
  - 全 Pundit 関連 PR が develop に揃ったら develop → main へまとめてマージ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 無効または期限切れの招待状に対するエラー処理を改善しました。

* **セキュリティ改善**
  * 招待状の作成とグループ参加時の認可チェックを強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->