### PR TITLE
Dashboard と Api::MemoryGames で policy_scope(Memory) を使用

### DIFF
--- a/app/controllers/api/memory_games_controller.rb
+++ b/app/controllers/api/memory_games_controller.rb
@@ -6,9 +6,9 @@ class Api::MemoryGamesController < ApplicationController
 
   def show
     # シンプルなJOINでIDのみ取得（with_attached_imageを使わない）
-    base_ids = current_user.memories
-                           .joins(:image_attachment)
-                           .pluck(:id)
+    base_ids = policy_scope(Memory)
+                 .joins(:image_attachment)
+                 .pluck(:id)
 
     total = base_ids.count
 
@@ -21,9 +21,9 @@ class Api::MemoryGamesController < ApplicationController
     selected_ids = base_ids.sample(MAXIMUM_CARDS)
 
     # 選んだIDで画像付きレコードを取得
-    selected = current_user.memories
-                           .with_attached_image
-                           .where(id: selected_ids)
+    selected = policy_scope(Memory)
+                 .with_attached_image
+                 .where(id: selected_ids)
 
     cards = selected.map do |memory|
       {

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,6 +2,6 @@ class DashboardController < ApplicationController
   before_action :authenticate_user!
 
   def top
-    @recent_memories = current_user.memories.with_attached_image.order(created_at: :desc).limit(6)
+    @recent_memories = policy_scope(Memory).with_attached_image.order(created_at: :desc).limit(6)
   end
 end


### PR DESCRIPTION
## 概要                                                         
  - `DashboardController#top` と `Api::MemoryGamesController#show` の `current_user.memories` を `policy_scope(Memory)` に置き換え                                                                                                             
  - Memory の閲覧範囲を `MemoryPolicy::Scope` に一元化                                                                                                                                                                                       
  - 続く `verify_authorized` 有効化 PR の前提を整える                                                                                                                                                                                          
                                                     
  ## 関連 Issue                                                                                                                                                                                                                                
  （Pundit 段階導入の補完。次 PR で `verify_authorized` を有効化予定）                                                                                                                                                                       
                                                                                                                                                                                                                                               
  ## 変更ファイル一覧                                                                                                                                                                                                                          
  | ファイル | 種別 | 変更理由 |                                  
  |---------|------|---------|                                                                                                                                                                                                                 
  | `app/controllers/dashboard_controller.rb` | 変更 | `current_user.memories` → `policy_scope(Memory)` |                                                                                                                                      
  | `app/controllers/api/memory_games_controller.rb` | 変更 | 同上（2 箇所） |                           
                                                                                                                                                                                                                                               
  ## 実装のポイント                                                                                                                                                                                                                            
                                                                                                                                                                                                                                               
  ### 動作変化なし                                                                                                                                                                                                                             
  `MemoryPolicy::Scope#resolve` は                             
  scope.where(user: user)                                                                                                                                                                                                                      
  を返すため、current_user.memories と 完全に同じ SQL を生成。                                                                                                                                          
                                                                                                                                
 ## テスト計画                                                                                                                                                                                                                                   
                                                                                                                   
  - [x] ローカル動作確認                                                                                                                                                                                                                           
    - /dashboard で最新 memory 6 件表示（従来通り）
    - 神経衰弱ゲーム API でカード生成（従来通り）                                                                                                                                                                                              
    - memory 不足時の対応（従来通り）                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                               
##  残件・TODO                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                               
  - 次 PR: verify_authorized 有効化 + 全コントローラへの skip 配置                                                                                                                                                                                                                                           
  - 全 Pundit 関連 PR が develop に揃ったら develop → main へまとめてマージ   