### PR TITLE
verify_authorized を有効化し全コントローラに認可検証を強制

### DIFF
--- a/app/controllers/api/memory_games_controller.rb
+++ b/app/controllers/api/memory_games_controller.rb
@@ -1,5 +1,7 @@
 class Api::MemoryGamesController < ApplicationController
   before_action :authenticate_user!
+  # policy_scope のみで authorize を呼ばないため verify_authorized を除外。
+  skip_after_action :verify_authorized
 
   MINIMUM_CARDS = 2
   MAXIMUM_CARDS = 8

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,8 +6,12 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!, unless: :devise_controller?
 
+  # 各アクションで authorize が呼ばれているかを検証する。
+  # 認可不要なアクションは個別コントローラで skip_after_action :verify_authorized する。
+  # Devise 系コントローラは認証ライブラリ側が責務を持つため一括除外。
+  after_action :verify_authorized, unless: :devise_controller?
+
   # Pundit::NotAuthorizedError を捕捉し、flash + 元のページへ戻すハンドリング。
-  # verify_authorized は意図的に有効化していない（既存コントローラへの段階導入のため）。
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   protected

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,5 +1,7 @@
 class DashboardController < ApplicationController
   before_action :authenticate_user!
+  # policy_scope のみで authorize を呼ばないため verify_authorized を除外。
+  skip_after_action :verify_authorized
 
   def top
     @recent_memories = policy_scope(Memory).with_attached_image.order(created_at: :desc).limit(6)

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -4,6 +4,8 @@ class InvitationsController < ApplicationController
   # 招待リンクのURLはログイン不要でアクセスできる
   skip_before_action :authenticate_user!, only: %i[show]
   before_action :set_and_validate_invitation, only: %i[show join]
+  # show は token 検証のみで Pundit を経由しない設計のため verify_authorized を除外。
+  skip_after_action :verify_authorized, only: :show
 
   # 招待リンクの発行（owner であることは InvitationPolicy#create? で検証）
   def create

--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -1,6 +1,8 @@
 class MemoriesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_memory, only: %i[show edit update destroy]
+  # index は policy_scope のみで authorize を呼ばないため verify_authorized を除外。
+  skip_after_action :verify_authorized, only: :index
 
   def index
     @my_memories = policy_scope(Memory).with_attached_image.order(created_at: :desc)

--- a/app/controllers/memory_games_controller.rb
+++ b/app/controllers/memory_games_controller.rb
@@ -1,5 +1,7 @@
 class MemoryGamesController < ApplicationController
   before_action :authenticate_user!
+  # ゲーム画面の表示のみで認可対象レコードが無いため verify_authorized を除外。
+  skip_after_action :verify_authorized
 
   def show; end
 end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,4 +1,7 @@
 class MypagesController < ApplicationController
+  # 自分自身のプロフィール表示のため Pundit による認可は不要。
+  skip_after_action :verify_authorized
+
   def show
     @user = current_user
     @family_group = current_user.family_groups.first

--- a/app/controllers/public_memories_controller.rb
+++ b/app/controllers/public_memories_controller.rb
@@ -1,6 +1,8 @@
 class PublicMemoriesController < ApplicationController
   # 認証不要 - 公開された思い出は誰でも見れるようにするため
   skip_before_action :authenticate_user!
+  # 公開情報を扱うため Pundit を経由しない設計（Memory.publicly_available を直接使用）。
+  skip_after_action :verify_authorized
   # 例外処理 - 公開されていない思い出にアクセスした場合は一覧ページにリダイレクトしてエラーメッセージを表示
   rescue_from ActiveRecord::RecordNotFound, with: :memory_not_found
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,7 @@
 class StaticPagesController < ApplicationController
   skip_before_action :authenticate_user!
+  # 未認証ランディングのため Pundit による認可は不要。
+  skip_after_action :verify_authorized
 
   def top
   end


### PR DESCRIPTION
 ## 概要                                                        
  - `ApplicationController` に `after_action :verify_authorized` を追加し、各アクションで `authorize` が呼ばれているかを Pundit に自動検証させる                                                                                              
  - Devise 系は `unless: :devise_controller?` で一括除外                                                                                                                                                                                    
  - 認可不要なアクションを持つ 8 コントローラに `skip_after_action :verify_authorized` を追加し、意図的にスキップしている箇所を明示                                                                                                           
                                                                                                                                   
  ## 関連 Issue                                                                                                                                                                                                                               
  （Pundit 段階導入の最終段。これで認可漏れ検出機構が稼働）                                                                                                                                                                                   
                                                                                                                                                                                                                                              
  ## 変更ファイル一覧                                                                                                                                                                                                                         
  | ファイル | 種別 | 変更理由 |                                                                                                                                                                                                            
  |---------|------|---------|                                                                                                                                                                                                                
  | `app/controllers/application_controller.rb` | 変更 | `after_action :verify_authorized` を追加 |                                                                                                                                         
  | `app/controllers/memories_controller.rb` | 変更 | `index` をスキップ（policy_scope のみ） |                                                                                                                                               
  | `app/controllers/invitations_controller.rb` | 変更 | `show` をスキップ（token 検証） |     
  | `app/controllers/dashboard_controller.rb` | 変更 | スキップ（policy_scope のみ） |                                                                                                                                                        
  | `app/controllers/api/memory_games_controller.rb` | 変更 | スキップ（policy_scope のみ） |                                                                                                                                                 
  | `app/controllers/mypages_controller.rb` | 変更 | スキップ（自分自身） |                                                                                                                                                                   
  | `app/controllers/memory_games_controller.rb` | 変更 | スキップ（空アクション） |                                                                                                                                                          
  | `app/controllers/static_pages_controller.rb` | 変更 | スキップ（未認証ランディング） |                                                                                                                                                    
  | `app/controllers/public_memories_controller.rb` | 変更 | スキップ（公開情報・Pundit 非経由） |                                                                                                                                            
                                                                                                                    
  
                                                                                                                                                                                                                                              
  ## テスト計画                                                                                                                                                                                                                               
  - [x] ローカル動作確認                                                                                                                                                                                                                      
    - 各画面（ランディング / dashboard / memories 各アクション / family_groups 各アクション / invitations 全フロー / public_memories / mypage / 神経衰弱）が `AuthorizationNotPerformedError` を出さずに動作                                  
    - `Pundit::NotAuthorizedError` の rescue_from 経路（他人 memory 直叩き等）が引き続き動作                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                              
  ## 残件・TODO                                                                                                                                                                                                                                                                                                                                                                                               
  - 段階導入完了後にメッセージ最適化（汎用「操作する権限がありません」をアクション固有メッセージへ）検討                                                                                                                                      
  - 全 Pundit 関連 PR が develop に揃ったら develop → main へまとめてマージ  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 権限認可システムの検証ロジックを最適化。アプリケーション全体の権限チェック機構を強化し、権限検証が必要のない特定のコントローラーアクションではスキップするよう改善しました。これにより、セキュリティと効率性が向上しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->