### PR TITLE
  [Release] Pundit による認可基盤の段階導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,9 @@ gem "cloudinary"
 # meta-tags - メタタグ管理
 gem "meta-tags"
 
+# Pundit - 認可（Policy ベース）
+gem "pundit"
+
 group :development, :test do
   # debug - デバッグツール
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,6 +264,8 @@ GEM
     public_suffix (7.0.0)
     puma (7.2.0)
       nio4r (~> 2.0)
+    pundit (2.5.2)
+      activesupport (>= 3.0.0)
     racc (1.8.1)
     rack (3.2.4)
     rack-protection (4.2.1)
@@ -448,6 +450,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection
   pg (~> 1.1)
   puma (>= 5.0)
+  pundit
   rails (~> 7.2.2)
   rails-i18n
   rubocop-rails-omakase

--- a/app/controllers/api/memory_games_controller.rb
+++ b/app/controllers/api/memory_games_controller.rb
@@ -6,9 +6,9 @@ class Api::MemoryGamesController < ApplicationController
 
   def show
     # シンプルなJOINでIDのみ取得（with_attached_imageを使わない）
-    base_ids = current_user.memories
-                           .joins(:image_attachment)
-                           .pluck(:id)
+    base_ids = policy_scope(Memory)
+                 .joins(:image_attachment)
+                 .pluck(:id)
 
     total = base_ids.count
 
@@ -21,9 +21,9 @@ class Api::MemoryGamesController < ApplicationController
     selected_ids = base_ids.sample(MAXIMUM_CARDS)
 
     # 選んだIDで画像付きレコードを取得
-    selected = current_user.memories
-                           .with_attached_image
-                           .where(id: selected_ids)
+    selected = policy_scope(Memory)
+                 .with_attached_image
+                 .where(id: selected_ids)
 
     cards = selected.map do |memory|
       {

--- a/app/controllers/api/memory_games_controller.rb
+++ b/app/controllers/api/memory_games_controller.rb
@@ -1,5 +1,7 @@
 class Api::MemoryGamesController < ApplicationController
   before_action :authenticate_user!
+  # policy_scope のみで authorize を呼ばないため verify_authorized を除外。
+  skip_after_action :verify_authorized
 
   MINIMUM_CARDS = 2
   MAXIMUM_CARDS = 8

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,8 +6,12 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!, unless: :devise_controller?
 
+  # 各アクションで authorize が呼ばれているかを検証する。
+  # 認可不要なアクションは個別コントローラで skip_after_action :verify_authorized する。
+  # Devise 系コントローラは認証ライブラリ側が責務を持つため一括除外。
+  after_action :verify_authorized, unless: :devise_controller?
+
   # Pundit::NotAuthorizedError を捕捉し、flash + 元のページへ戻すハンドリング。
-  # verify_authorized は意図的に有効化していない（既存コントローラへの段階導入のため）。
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   protected

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,14 @@
 class ApplicationController < ActionController::Base
+  include Pundit::Authorization
+
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!, unless: :devise_controller?
+
+  # Pundit::NotAuthorizedError を捕捉し、flash + 元のページへ戻すハンドリング。
+  # verify_authorized は意図的に有効化していない（既存コントローラへの段階導入のため）。
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   protected
 
@@ -10,5 +16,12 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
     devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
+  end
+
+  private
+
+  def user_not_authorized
+    flash[:alert] = t("pundit.not_authorized")
+    redirect_back fallback_location: root_path
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,5 +1,7 @@
 class DashboardController < ApplicationController
   before_action :authenticate_user!
+  # policy_scope のみで authorize を呼ばないため verify_authorized を除外。
+  skip_after_action :verify_authorized
 
   def top
     @recent_memories = policy_scope(Memory).with_attached_image.order(created_at: :desc).limit(6)

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,6 +2,6 @@ class DashboardController < ApplicationController
   before_action :authenticate_user!
 
   def top
-    @recent_memories = current_user.memories.with_attached_image.order(created_at: :desc).limit(6)
+    @recent_memories = policy_scope(Memory).with_attached_image.order(created_at: :desc).limit(6)
   end
 end

--- a/app/controllers/family_groups_controller.rb
+++ b/app/controllers/family_groups_controller.rb
@@ -4,10 +4,12 @@ class FamilyGroupsController < ApplicationController
 
   def new
     @family_group = FamilyGroup.new
+    authorize @family_group
   end
 
   def create
     @family_group = FamilyGroup.new(family_group_params)
+    authorize @family_group
 
     # グループ作成とオーナー登録をトランザクションでまとめる
     ActiveRecord::Base.transaction do
@@ -20,7 +22,7 @@ class FamilyGroupsController < ApplicationController
   rescue ActiveRecord::RecordInvalid
     flash.now[:alert] = "家族グループの作成に失敗しました"
     render :new, status: :unprocessable_entity
-  rescue ActiveRecord::RecordNotUnique # ユーザーが既にグループに所属している場合の例外
+  rescue ActiveRecord::RecordNotUnique # race condition 等の防御的フォールバック
     redirect_to mypage_path, alert: "既に家族グループに所属しています"
   end
 
@@ -46,15 +48,10 @@ class FamilyGroupsController < ApplicationController
   end
 
   def destroy
-    # オーナーのみグループ削除可能
-    if @family_group.user_family_groups.find_by(user: current_user)&.owner?
-      if @family_group.destroy
-        redirect_to mypage_path, notice: "家族グループが削除されました"
-      else
-        redirect_to @family_group, alert: "家族グループの削除に失敗しました"
-      end
+    if @family_group.destroy
+      redirect_to mypage_path, notice: "家族グループが削除されました"
     else
-      redirect_to @family_group, alert: "家族グループの削除はオーナーのみ可能です"
+      redirect_to @family_group, alert: "家族グループの削除に失敗しました"
     end
   end
 
@@ -64,7 +61,9 @@ class FamilyGroupsController < ApplicationController
     params.require(:family_group).permit(:name)
   end
 
+  # 非メンバーには 404（存在を隠す）、メンバー以上には authorize で操作種別を判定する二段防衛。
   def set_family_group
-    @family_group = current_user.family_groups.find_by!(uuid: params[:uuid])
+    @family_group = policy_scope(FamilyGroup).find_by!(uuid: params[:uuid])
+    authorize @family_group
   end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -4,6 +4,8 @@ class InvitationsController < ApplicationController
   # 招待リンクのURLはログイン不要でアクセスできる
   skip_before_action :authenticate_user!, only: %i[show]
   before_action :set_and_validate_invitation, only: %i[show join]
+  # show は token 検証のみで Pundit を経由しない設計のため verify_authorized を除外。
+  skip_after_action :verify_authorized, only: :show
 
   # 招待リンクの発行（owner であることは InvitationPolicy#create? で検証）
   def create

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -38,7 +38,7 @@ class InvitationsController < ApplicationController
 
     # 招待リンクの有効性と期限切れのチェック
     if @invitation.nil? || @invitation.expired?
-      redirect_to root_path, alert: "招待リンクが無効または期限切れです"
+      return redirect_to root_path, alert: "招待リンクが無効または期限切れです"
     end
 
     # ログインしていない場合はURLを保存し、ログインページへリダイレクト

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -23,7 +23,7 @@ class InvitationsController < ApplicationController
   def join
     @family_group = @invitation.family_group
     membership = UserFamilyGroup.new(user: current_user, family_group: @family_group, role: :member)
-    authorize membership
+    authorize membership, :create?
     membership.save!
     redirect_to mypage_path, notice: "#{@family_group.name}に参加しました"
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -5,25 +5,26 @@ class InvitationsController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[show]
   before_action :set_and_validate_invitation, only: %i[show join]
 
-  # 招待リンクの発行(サーバー側でもう一度オーナーであることを確認)
+  # 招待リンクの発行（owner であることは InvitationPolicy#create? で検証）
   def create
-    membership = current_user.user_family_groups.find_by!(
-      family_group_id: params[:family_group_id],
-      role: :owner
-      )
-    family_group = membership.family_group
-    family_group.invitations.create!
-    redirect_to family_group, notice: "招待リンクが発行されました"
+    @invitation = Invitation.new(family_group_id: params[:family_group_id])
+    authorize @invitation
+    @invitation.save!
+    redirect_to @invitation.family_group, notice: "招待リンクが発行されました"
   end
 
   def show
     @family_group = @invitation.family_group
   end
 
-  # 招待リンクを踏んで参加するアクション
+  # 招待リンクを踏んで参加するアクション。
+  # トークン検証は set_and_validate_invitation で済むが、authorize で
+  # UserFamilyGroupPolicy#create? も通すことで verify_authorized 有効化時に対応できる構成にしておく。
   def join
     @family_group = @invitation.family_group
-    UserFamilyGroup.create!(user: current_user, family_group: @family_group, role: :member) # メンバー権限として参加
+    membership = UserFamilyGroup.new(user: current_user, family_group: @family_group, role: :member)
+    authorize membership
+    membership.save!
     redirect_to mypage_path, notice: "#{@family_group.name}に参加しました"
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
     redirect_to invitation_path(params[:token]), alert: "グループへの参加に失敗しました"

--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -1,16 +1,19 @@
 class MemoriesController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_memory, only: %i[show edit update destroy]
 
   def index
-    @my_memories = current_user.memories.with_attached_image.order(created_at: :desc)
+    @my_memories = policy_scope(Memory).with_attached_image.order(created_at: :desc)
   end
 
   def new
     @memory = Memory.new
+    authorize @memory
   end
 
   def create
     @memory = current_user.memories.build(memory_params)
+    authorize @memory
 
     begin
       if params[:memory][:image].present?
@@ -33,12 +36,9 @@ class MemoriesController < ApplicationController
   end
 
   def edit
-    @memory = current_user.memories.find_by!(uuid: params[:uuid])
   end
 
   def update
-    @memory = current_user.memories.find_by!(uuid: params[:uuid])
-
     begin
       @memory.assign_attributes(memory_params.except(:image))
       # 画像がアップロードされている場合のみ画像処理を実行
@@ -62,18 +62,19 @@ class MemoriesController < ApplicationController
   end
 
   def destroy
-    memory = current_user.memories.find_by!(uuid: params[:uuid])
-    memory.destroy!
+    @memory.destroy!
     redirect_to memories_path, notice: t("defaults.flash_message.deleted", model: Memory.model_name.human)
   end
 
-
-
   def show
-    @memory = current_user.memories.find_by!(uuid: params[:uuid])
   end
 
   private
+
+  def set_memory
+    @memory = Memory.find_by!(uuid: params[:uuid])
+    authorize @memory
+  end
 
   def memory_params
     params.require(:memory).permit(:title, :description, :memory_date, :visibility, :image)

--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -1,6 +1,8 @@
 class MemoriesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_memory, only: %i[show edit update destroy]
+  # index は policy_scope のみで authorize を呼ばないため verify_authorized を除外。
+  skip_after_action :verify_authorized, only: :index
 
   def index
     @my_memories = policy_scope(Memory).with_attached_image.order(created_at: :desc)

--- a/app/controllers/memory_games_controller.rb
+++ b/app/controllers/memory_games_controller.rb
@@ -1,5 +1,7 @@
 class MemoryGamesController < ApplicationController
   before_action :authenticate_user!
+  # ゲーム画面の表示のみで認可対象レコードが無いため verify_authorized を除外。
+  skip_after_action :verify_authorized
 
   def show; end
 end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,4 +1,7 @@
 class MypagesController < ApplicationController
+  # 自分自身のプロフィール表示のため Pundit による認可は不要。
+  skip_after_action :verify_authorized
+
   def show
     @user = current_user
     @family_group = current_user.family_groups.first

--- a/app/controllers/public_memories_controller.rb
+++ b/app/controllers/public_memories_controller.rb
@@ -1,6 +1,8 @@
 class PublicMemoriesController < ApplicationController
   # 認証不要 - 公開された思い出は誰でも見れるようにするため
   skip_before_action :authenticate_user!
+  # 公開情報を扱うため Pundit を経由しない設計（Memory.publicly_available を直接使用）。
+  skip_after_action :verify_authorized
   # 例外処理 - 公開されていない思い出にアクセスした場合は一覧ページにリダイレクトしてエラーメッセージを表示
   rescue_from ActiveRecord::RecordNotFound, with: :memory_not_found
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,7 @@
 class StaticPagesController < ApplicationController
   skip_before_action :authenticate_user!
+  # 未認証ランディングのため Pundit による認可は不要。
+  skip_after_action :verify_authorized
 
   def top
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,35 @@
+# Pundit Policy の基底クラス。
+# 各リソースの Policy はこのクラスを継承し、`#index?` や `#update?` などの述語メソッドで
+# 認可ルールを宣言する。controller 側では `authorize @record` を呼ぶことで
+# 対応する Policy のメソッドが呼ばれ、false を返すと Pundit::NotAuthorizedError が発生する。
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?     = false
+  def show?      = false
+  def create?    = false
+  def new?       = create?
+  def update?    = false
+  def edit?      = update?
+  def destroy?   = false
+
+  # index アクションでログインユーザーが閲覧可能なレコード集合を返す Scope。
+  # `policy_scope(Model)` を controller で呼ぶと `Scope.new(current_user, Model).resolve` が走る。
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      raise NoMethodError, "You must define #resolve in #{self.class}"
+    end
+  end
+end

--- a/app/policies/family_group_policy.rb
+++ b/app/policies/family_group_policy.rb
@@ -1,0 +1,29 @@
+# FamilyGroup に対する認可ルール。
+# 1 ユーザー 1 グループ制約があるため、create? は未所属ユーザーのみ許可する。
+class FamilyGroupPolicy < ApplicationPolicy
+  def index?   = user.present?
+  def show?    = member?
+  def create?  = user.present? && user.user_family_groups.empty?
+  def update?  = owner?
+  def destroy? = owner?
+
+  # 自分が所属しているグループのみ可視。
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope.none if user.nil?
+      scope.joins(:user_family_groups).where(user_family_groups: { user_id: user.id })
+    end
+  end
+
+  private
+
+  def member?
+    return false if user.nil?
+    record.user_family_groups.exists?(user_id: user.id)
+  end
+
+  def owner?
+    return false if user.nil?
+    record.user_family_groups.exists?(user_id: user.id, role: :owner)
+  end
+end

--- a/app/policies/invitation_policy.rb
+++ b/app/policies/invitation_policy.rb
@@ -1,0 +1,26 @@
+# Invitation（家族グループへの招待リンク）に対する認可ルール。
+# 招待リンクの発行・閲覧・削除はグループの owner のみ可能。
+# 招待トークン経由の受諾フローは未認証ユーザーでも辿れるが、その経路は
+# Pundit を経由せず、コントローラ側で token 検証で代替する想定。
+class InvitationPolicy < ApplicationPolicy
+  def index?   = group_owner?
+  def show?    = group_owner?
+  def create?  = group_owner?
+  def destroy? = group_owner?
+
+  # 自分が owner であるグループの招待のみ可視。
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope.none if user.nil?
+      owned_group_ids = UserFamilyGroup.where(user_id: user.id, role: :owner).select(:family_group_id)
+      scope.where(family_group_id: owned_group_ids)
+    end
+  end
+
+  private
+
+  def group_owner?
+    return false if user.nil?
+    UserFamilyGroup.exists?(family_group_id: record.family_group_id, user_id: user.id, role: :owner)
+  end
+end

--- a/app/policies/memory_policy.rb
+++ b/app/policies/memory_policy.rb
@@ -1,0 +1,26 @@
+# Memory に対する認可ルール。
+# 公開済み (published) 投稿は所有者以外も閲覧可能、それ以外は所有者のみ操作可能。
+#
+# Scope は MemoriesController（認証必須・自分の投稿一覧）向けに「自分の投稿のみ」を返す。
+# PublicMemoriesController は公開情報を扱うため Pundit を経由しない設計（Memory.publicly_available を直接使用）。
+class MemoryPolicy < ApplicationPolicy
+  def index?   = true
+  def show?    = record.published? || owner?
+  def create?  = user.present?
+  def update?  = owner?
+  def destroy? = owner?
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope.none if user.nil?
+      scope.where(user: user)
+    end
+  end
+
+  private
+
+  def owner?
+    return false if user.nil?
+    record.user_id == user.id
+  end
+end

--- a/app/policies/user_family_group_policy.rb
+++ b/app/policies/user_family_group_policy.rb
@@ -1,0 +1,33 @@
+# UserFamilyGroup（グループメンバーシップ）に対する認可ルール。
+# 招待経由の自己参加 / 自己脱退と、owner による他メンバー管理を許可する。
+class UserFamilyGroupPolicy < ApplicationPolicy
+  def show?    = same_group_member?
+  def create?  = user.present? && record.user_id == user.id
+  def update?  = group_owner?
+  def destroy? = self_membership? || group_owner?
+
+  # 自分が属するグループのメンバーシップのみ可視。
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope.none if user.nil?
+      scope.where(family_group_id: user.family_groups.select(:id))
+    end
+  end
+
+  private
+
+  def same_group_member?
+    return false if user.nil?
+    user.family_groups.exists?(id: record.family_group_id)
+  end
+
+  def self_membership?
+    return false if user.nil?
+    record.user_id == user.id
+  end
+
+  def group_owner?
+    return false if user.nil?
+    UserFamilyGroup.exists?(family_group_id: record.family_group_id, user_id: user.id, role: :owner)
+  end
+end

--- a/config/locales/pundit.ja.yml
+++ b/config/locales/pundit.ja.yml
@@ -1,0 +1,3 @@
+ja:
+  pundit:
+    not_authorized: 操作する権限がありません


### PR DESCRIPTION
## 概要                                                        
  Pundit を導入し、Policy ベースの認可基盤を全コントローラに段階適用した一連の変更を main に反映する。本リリースで本番環境に Pundit による認可機構が稼働する。                                                                                
                                                                                                                                                                                                                                              
  ユーザー側の主要な動作変化は **「他人のリソースへの直接アクセス時に flash + redirect_back を返す」** 点と、**「家族グループに既に所属しているユーザーは `/family_groups/new` を開いた時点で弾かれる」** 点（Before                          
  はフォーム表示後にエラー）。それ以外は従来通りに動作する。                                                                                                                                                                                  
                                                                                                                                                                                                                                              
  ## 含まれるマージ済み PR                                                                                          
  1. #206 — gem 追加 + ApplicationController に NotAuthorizedError ハンドリング
  2. #208— Memory / FamilyGroup / UserFamilyGroup / Invitation の 4 Policy                                                                                               
  3. #209                                                                                                                                                                                    
  4. #211                                                                                                                                                                            
  5. #212                                                                                                                                     
  6. #213                                                                                                                                                            
  7. #215                                                                                                                                                       
                                                                                                                                                                                                                                              
  ## 主な変更ファイル                                                                                                                                                                                                                         
  | 区分 | ファイル | 内容 |                                                                                                                                                                                                                  
  |---|---|---|                                                                                                                                                                                                                               
  | 設定 | `Gemfile` / `Gemfile.lock` | `pundit` 追加 |          
  | 共通 | `app/controllers/application_controller.rb` | Pundit::Authorization include / NotAuthorizedError 捕捉 / verify_authorized 有効化 |                                                                                                 
  | Policy | `app/policies/application_policy.rb` | 基底クラス（全述語デフォルト false） |                                                                                                                                                    
  | Policy | `app/policies/memory_policy.rb` | 公開済みは誰でも閲覧可、それ以外は所有者のみ。Scope は自分の投稿のみ |                                                                                                                         
  | Policy | `app/policies/family_group_policy.rb` | show=member、create=未所属者、update/destroy=owner |                                                                                                                                     
  | Policy | `app/policies/user_family_group_policy.rb` | 自己参加・自己脱退 + owner による他メンバー管理 |                                                                                                                                   
  | Policy | `app/policies/invitation_policy.rb` | 全アクション owner のみ。トークン経路は Pundit 非経由 |                                                                                                                                    
  | Controller | `app/controllers/memories_controller.rb` | policy_scope / authorize 適用、set_memory に統合 |                                                                                                                                
  | Controller | `app/controllers/family_groups_controller.rb` | policy_scope + authorize の二段防衛、destroy のインライン owner チェック撤去 |                                                                                               
  | Controller | `app/controllers/invitations_controller.rb` | create / join に authorize 適用、set_and_validate_invitation の return 漏れ修正 |                                                                                              
  | Controller | `app/controllers/dashboard_controller.rb` / `api/memory_games_controller.rb` | policy_scope に置換 |                                                                                                                         
  | Controller | その他 6 コントローラ | `skip_after_action :verify_authorized` で意図的な認可不要を明示 |                                                                                                                                    
  | i18n | `config/locales/pundit.ja.yml` | 未認可時メッセージの I18n 化 |                                                                                                                                                                    
                                                                                                                                                                                                                                              
  ## 設計の重要ポイント                                                                                                                                                                                                                       
                                                                                                                                                                                                                                              
  ### 1. 二段防衛（FamilyGroupsController）                                                                                                                                                                                                   
  `set_family_group` で `policy_scope(FamilyGroup)` + `authorize @family_group` を併用し、非メンバーには 404（存在隠蔽）、メンバー非 owner には 403（操作不可）を返す構成。Defense in depth。
                                                                                                                                                                                                                                              
  ### 2. 公開情報と機微情報の使い分け                                                                                                                                                                                                         
  - Memory: `find_by!` + `authorize` — 公開投稿は存在を漏らしてもよい設計                                                                                                                                                                     
  - FamilyGroup: `policy_scope.find_by!` + `authorize` — 非メンバーには存在自体を隠す                                                                                                                                                         
                                                                                                                                                                                                                                              
  ### 3. Pundit を経由しないコントローラの明示                                                                                                                                                                                                
  - `PublicMemoriesController`: 公開情報 — Pundit 非経由                                                                                                                                                                                      
  - `InvitationsController#show`: 招待トークン経路 — Pundit 非経由（token 検証で代替）                                                                                                                                                        
  - 上記とその他認可不要コントローラはすべて `skip_after_action :verify_authorized` で意図を明示                                                                                                                                              
                                                                                                                                                                                                                                              
  ### 4. verify_authorized による認可漏れ検出                                                                                                                                                                                                 
  新規コントローラやアクションで `authorize` 呼び忘れ時に `Pundit::AuthorizationNotPerformedError` が発生し、開発・CI 段階で検出可能。                                                                                                        
                                                                                                                                                                                                                                              
  ## ユーザーへの動作変化点                                                                                         
  | シナリオ | Before | After |                                                                                                                                                                                                               
  |---|---|---|                                                                                                     
  | 他人の memory uuid を直叩き | RecordNotFound（404） | flash「操作する権限がありません」+ redirect_back |                                                                                                                                  
  | 非メンバーが他人の家族グループ uuid を直叩き | RecordNotFound（404） | RecordNotFound（404）※二段防衛で同等 |                                                                                                                             
  | 既所属ユーザーが `/family_groups/new` | フォーム表示 → submit 後に「既に所属」 | フォーム表示前に flash + redirect_back |                                                                                                                 
  | owner 以外が招待発行 API を直叩き | RecordNotFound（404） | flash + redirect_back |                                                                                                                                                       
  | 通常の閲覧・編集・作成・削除 | — | 従来通り動作 |                                                                                                                                                                                         
                                                                                                                                                                                                                                              
  ## テスト                                                                                                                                                                                                                                   
  - [x] 各 feature PR 単位でローカル動作確認済み                                                                                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                              
  ## 残件・次のタスク                                                                                                                                                                                                                         
  - **次タスク:** RSpec セットアップ + Policy spec 一括追加（別 develop ベースの PR で進行予定）                                                                                                                                              
  - 段階導入完了後の **メッセージ最適化**（汎用「操作する権限がありません」→ アクション固有メッセージ）も今後検討                                                                                                                             
  - `verify_policy_scoped` の有効化検討（現状は意図的に見送り）                                                                                                                                                                               
