### PR TITLE
家族グループのメンバーシップ管理機能を追加 

### DIFF
--- a/app/controllers/family_groups_controller.rb
+++ b/app/controllers/family_groups_controller.rb
@@ -39,11 +39,7 @@ class FamilyGroupsController < ApplicationController
   end
 
   def show
-    # ログインユーザーのグループ内での役割を取得
-    @current_membership = @family_group.user_family_groups.find_by(user: current_user)
-    # オーナーかどうかを判定し、ビュー側で条件分岐できるようにインスタンス変数にセット
-    @is_owner = @current_membership&.owner?
-    # 最新の招待リンクを取得（存在する場合）
+    # 最新の招待リンクを取得（存在する場合）。owner 判定は view 側で policy(...) を用いる。
     @latest_invitation = @family_group.invitations.where("expires_at > ?", Time.current).order(created_at: :desc).first
   end
 

--- a/app/controllers/user_family_groups_controller.rb
+++ b/app/controllers/user_family_groups_controller.rb
@@ -1,0 +1,36 @@
+class UserFamilyGroupsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_family_group
+
+  # メンバーの役割変更（owner ⇄ member）。
+  def update
+    @membership = @family_group.user_family_groups.find(params[:id])
+    authorize @membership
+
+    if @membership.update(role: params[:role])
+      redirect_to @family_group, notice: t("mypage.family_group.show.role_updated")
+    else
+      redirect_to @family_group, alert: @membership.errors.full_messages.to_sentence
+    end
+  end
+
+  # 自分自身の脱退のみ対象（owner kick は本機能では扱わない）。
+  # current_user.user_family_groups で取得することで他人のメンバーシップ削除を弾く。
+  def destroy
+    @membership = current_user.user_family_groups.find(params[:id])
+    authorize @membership
+
+    if @membership.destroy
+      redirect_to mypage_path, notice: t("mypage.family_group.show.left_group")
+    else
+      redirect_to @family_group, alert: @membership.errors.full_messages.to_sentence
+    end
+  end
+
+  private
+
+  # 非メンバーには 404（存在隠蔽）、メンバー以上には authorize で操作種別を判定する二段防衛。
+  def set_family_group
+    @family_group = policy_scope(FamilyGroup).find_by!(uuid: params[:family_group_uuid])
+  end
+end

--- a/app/controllers/user_family_groups_controller.rb
+++ b/app/controllers/user_family_groups_controller.rb
@@ -3,11 +3,19 @@ class UserFamilyGroupsController < ApplicationController
   before_action :set_family_group
 
   # メンバーの役割変更（owner ⇄ member）。
+  # family_group 行を pessimistic lock することで、同時に複数の owner を
+  # member に降格して owner が 0 人になる race condition を防ぐ。
   def update
     @membership = @family_group.user_family_groups.find(params[:id])
     authorize @membership
 
-    if @membership.update(role: params[:role])
+    succeeded = false
+    ActiveRecord::Base.transaction do
+      @family_group.lock!
+      succeeded = @membership.update(role: params[:role])
+    end
+
+    if succeeded
       redirect_to @family_group, notice: t("mypage.family_group.show.role_updated")
     else
       redirect_to @family_group, alert: @membership.errors.full_messages.to_sentence
@@ -16,11 +24,18 @@ class UserFamilyGroupsController < ApplicationController
 
   # 自分自身の脱退のみ対象（owner kick は本機能では扱わない）。
   # current_user.user_family_groups で取得することで他人のメンバーシップ削除を弾く。
+  # update と同様に family_group 行をロックして同時脱退の race condition を防ぐ。
   def destroy
     @membership = current_user.user_family_groups.find(params[:id])
     authorize @membership
 
-    if @membership.destroy
+    succeeded = false
+    ActiveRecord::Base.transaction do
+      @family_group.lock!
+      succeeded = @membership.destroy
+    end
+
+    if succeeded
       redirect_to mypage_path, notice: t("mypage.family_group.show.left_group")
     else
       redirect_to @family_group, alert: @membership.errors.full_messages.to_sentence

--- a/app/models/user_family_group.rb
+++ b/app/models/user_family_group.rb
@@ -5,4 +5,31 @@ class UserFamilyGroup < ApplicationRecord
   enum :role, { owner: 0, member: 1 }  # defaultはmember
 
   validates :user_id, uniqueness: { message: "は1つの家族グループにしか所属できません" }
+
+  # 最後のオーナーが member に降格されないようにする（操作後に owner が 0 人になる変更を弾く）。
+  validate :must_keep_at_least_one_owner_after_demotion, on: :update
+
+  # 最後のオーナーが脱退できないようにする。
+  before_destroy :ensure_at_least_one_owner_remains_after_leave
+
+  private
+
+  def must_keep_at_least_one_owner_after_demotion
+    return unless role_changed? && role_was == "owner"
+    return if other_owners_exist?
+
+    errors.add(:role, "を変更するには、別のメンバーをオーナーに指定してください")
+  end
+
+  def ensure_at_least_one_owner_remains_after_leave
+    return unless owner?
+    return if other_owners_exist?
+
+    errors.add(:base, "最後のオーナーが脱退するには、別のメンバーをオーナーに指定してください")
+    throw :abort
+  end
+
+  def other_owners_exist?
+    family_group.user_family_groups.where(role: :owner).where.not(id: id).exists?
+  end
 end

--- a/app/models/user_family_group.rb
+++ b/app/models/user_family_group.rb
@@ -2,7 +2,9 @@ class UserFamilyGroup < ApplicationRecord
   belongs_to :user
   belongs_to :family_group
 
-  enum :role, { owner: 0, member: 1 }  # defaultはmember
+  # validate: true により、enum に存在しない値の代入で ArgumentError を発生させる代わりに
+  # validation エラーとして扱う（params 経由で来る不正値で 500 になるのを防ぐ）。
+  enum :role, { owner: 0, member: 1 }, validate: true  # defaultはmember
 
   validates :user_id, uniqueness: { message: "は1つの家族グループにしか所属できません" }
 

--- a/app/policies/user_family_group_policy.rb
+++ b/app/policies/user_family_group_policy.rb
@@ -6,6 +6,10 @@ class UserFamilyGroupPolicy < ApplicationPolicy
   def update?  = group_owner?
   def destroy? = self_membership? || group_owner?
 
+  # 「自分自身の脱退」の可否（view のボタン表示判定で使用）。
+  # destroy? は owner kick も許可する permissive な定義のため、自己脱退の表示判定は分離する。
+  def leave? = self_membership?
+
   # 自分が属するグループのメンバーシップのみ可視。
   class Scope < ApplicationPolicy::Scope
     def resolve

--- a/app/views/family_groups/show.html.erb
+++ b/app/views/family_groups/show.html.erb
@@ -26,16 +26,44 @@
 
         <ul class="flex flex-col gap-3">
           <% @family_group.user_family_groups.includes(:user).each do |ufg| %>
-            <li class="flex items-center justify-between">
+            <li class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
               <div class="flex items-center gap-3">
                 <%= render "shared/user_avatar", user: ufg.user, size: :md %>
                 <span class="text-sm font-medium"><%= ufg.user.name %></span>
+                <% if ufg.owner? %>
+                  <span class="badge badge-primary badge-sm"><%= t('mypage.family_group.owner_badge') %></span>
+                <% else %>
+                  <span class="badge badge-ghost badge-sm"><%= t('mypage.family_group.member_badge') %></span>
+                <% end %>
               </div>
-              <% if ufg.owner? %>
-                <span class="badge badge-primary badge-sm"><%= t('mypage.family_group.owner_badge') %></span>
-              <% else %>
-                <span class="badge badge-ghost badge-sm"><%= t('mypage.family_group.member_badge') %></span>
-              <% end %>
+
+              <div class="flex flex-wrap items-center gap-2">
+                <% if policy(ufg).update? %>
+                  <% if ufg.member? %>
+                    <%= button_to t('mypage.family_group.show.promote_to_owner'),
+                                  family_group_user_family_group_path(@family_group, ufg),
+                                  method: :patch,
+                                  params: { role: "owner" },
+                                  data: { turbo_confirm: t('mypage.family_group.show.promote_confirm') },
+                                  class: "btn btn-xs btn-outline btn-primary" %>
+                  <% else %>
+                    <%= button_to t('mypage.family_group.show.demote_to_member'),
+                                  family_group_user_family_group_path(@family_group, ufg),
+                                  method: :patch,
+                                  params: { role: "member" },
+                                  data: { turbo_confirm: t('mypage.family_group.show.demote_confirm') },
+                                  class: "btn btn-xs btn-outline" %>
+                  <% end %>
+                <% end %>
+
+                <% if policy(ufg).leave? %>
+                  <%= button_to t('mypage.family_group.show.leave_group'),
+                                family_group_user_family_group_path(@family_group, ufg),
+                                method: :delete,
+                                data: { turbo_confirm: t('mypage.family_group.show.leave_confirm') },
+                                class: "btn btn-xs btn-outline btn-error" %>
+                <% end %>
+              </div>
             </li>
           <% end %>
         </ul>
@@ -43,7 +71,7 @@
     </div>
 
 
-    <% if @is_owner %>
+    <% if policy(@family_group).update? %>
       <!-- オーナーのみ招待リンク発行ボタンを表示 -->
       <div class="card bg-base-100 shadow-2xl border border-base-200">
         <div class="card-body p-6 gap-4">
@@ -87,7 +115,7 @@
         <%= t('mypage.family_group.show.return_to_mypage') %>
       <% end %>
 
-      <% if @is_owner %>
+      <% if policy(@family_group).destroy? %>
         <%= link_to family_group_path(@family_group),
               data: { turbo_method: :delete, turbo_confirm: "グループを解散しますか？この操作は取り消せません。" },
               class: "btn btn-error btn-outline btn-sm gap-2" do %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -15,6 +15,8 @@ ja:
         memory_date: 思い出の日付
         visibility: 公開範囲
         image: 画像
+      user_family_group:
+        role: 役割
   enums:
     memory:
       visibility:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -93,6 +93,14 @@ ja:
         generate_invitation: 招待リンクを発行する
         return_to_mypage: マイページに戻る
         disband_group: グループを解散する
+        promote_to_owner: オーナーにする
+        demote_to_member: メンバーにする
+        leave_group: グループから脱退する
+        promote_confirm: このメンバーをオーナーにしますか？
+        demote_confirm: このメンバーをメンバーに変更しますか？
+        leave_confirm: グループから脱退しますか？
+        role_updated: メンバーの役割を更新しました
+        left_group: グループから脱退しました
   invitation:
     show:
       title: グループへの招待

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,10 @@ Rails.application.routes.draw do
   resources :public_memories, param: :uuid, only: %i[index show]
 
   # 家族グループ - uuidをURLパラメータとして使用するため、param: :uuidを指定
-  resources :family_groups, param: :uuid, only: %i[new create update show destroy]
+  resources :family_groups, param: :uuid, only: %i[new create update show destroy] do
+    # メンバーシップ操作（役割変更・脱退）。member 中間テーブルのため id は数値 ID。
+    resources :user_family_groups, only: %i[update destroy]
+  end
 
   get "memory_game" => "memory_games#show", as: :memory_game
 


### PR DESCRIPTION
## 概要                                                                                                                                                                                                                                     
  - 家族グループのオーナーが他メンバーの役割を owner ⇄ member に変更できる機能を追加
  - メンバー（owner / member 問わず）が自分自身でグループを脱退できる機能を追加                                                                                                                                                               
  - 「最後の owner」が降格・脱退しようとした場合は validation / before_destroy で弾き、別メンバーへの owner 引き継ぎを促す                                                                                                                    
  - ビュー側の owner 判定ロジックを Pundit Policy に一元化（`@is_owner` を撤廃）                                                                                                                                                              
                                                                                                                                                                                                                                              
  ## 関連 Issue                                                                                                                                                                                                                               
  （家族グループ機能の拡張）                                                                                                                                                                                                                  
                                                                                                                                                                                                                                              
  ## 変更ファイル一覧                                                                                                                                                                                                                         
  | ファイル | 種別 | 変更理由 |                                                                                                                                                                                                            
  |---------|------|---------|                                   
  | `config/routes.rb` | 変更 | `family_groups` 配下に `user_family_groups` を nest（update / destroy） |                                                                                                                                     
  | `app/models/user_family_group.rb` | 変更 | 最後の owner 保護のための validation + before_destroy |   
  | `app/controllers/user_family_groups_controller.rb` | 新規 | update（役割変更）/ destroy（自己脱退）アクション |                                                                                                                           
  | `app/controllers/family_groups_controller.rb` | 変更 | `@is_owner` / `@current_membership` を撤廃 |                                                                                                                                       
  | `app/policies/user_family_group_policy.rb` | 変更 | 自己脱退ボタンの表示判定用に `leave?` メソッド追加 |                                                                                                                                  
  | `app/views/family_groups/show.html.erb` | 変更 | メンバー一覧に役割変更・脱退ボタン追加、Policy ベースの判定に統一 |                                                                                                                      
  | `config/locales/views/ja.yml` | 変更 | 役割変更・脱退に関する i18n キー追加 |   
 | `config/locales/activerecord/ja.yml` | 変更 | UserFamilyGroup の role 属性の日本語ラベル追加 |                                                                                                                                                             
                                                                                                                                                                                                                                              
  ## 実装のポイント                                                                                                                                                                                                                           
                                                                                                                                                                                                                                              
  ### 1. 認可とビジネスルールの分離                                                                                                                                                                                                           
  - **Pundit Policy**:「誰がこの操作を実行できるか」（owner のみ役割変更可、自分自身のみ脱退可）                                                                                                                                              
  - **モデル validation / before_destroy**:「データの整合性が保てるか」（最後の owner が消えないか）                
                                                                                                                                                                                                                                              
  両者は責務が異なるためレイヤを分離。Policy にビジネスルールを混ぜず、validation に認可ロジックを混ぜない。                                                                                                                                  
                                                                                                                                                                                                                                              
  ```ruby                                                                                                                                                                                                                                     
  # UserFamilyGroup                                                                                                 
  validate :must_keep_at_least_one_owner_after_demotion, on: :update                                                                                                                                                                          
  before_destroy :ensure_at_least_one_owner_remains_after_leave  # throw :abort   
```                                                                                                                                                            
                                                                               
###  2. 自己脱退限定（owner kick は本機能では未対応）                                                                                                                                                                                            
                                                                                                                                                                                                                                              
  コントローラの destroy で current_user.user_family_groups.find(params[:id]) とすることで、自分以外のメンバーシップ ID が来たら RecordNotFound で弾く。                                                                                      
                                                                                                                                                                                                                                              
  UserFamilyGroupPolicy#destroy? は self_membership? || group_owner? のままにし、表示判定用には leave? = self_membership? を別途追加。                                                                
                                                                                                                    
### 3. ビューの Policy 一元化                                                                                                                                                                                                                   
                                                                                                                    
  @is_owner（コントローラで設定）を撤廃し、ビュー内で policy(@family_group).update? / policy(@family_group).destroy? / policy(ufg).update? / policy(ufg).leave? を直接呼ぶ構成に変更。owner 判定ロジックがすべて Policy に集約。        
   
### 4. 二段防衛の継承                                                                                                                                                                                                                           
                                                                                                                    
  UserFamilyGroupsController#set_family_group は policy_scope(FamilyGroup).find_by!(uuid:) を採用。非メンバーが他人のグループ配下のメンバー操作 URL を叩いても 404（存在隠蔽）。FamilyGroupsController と同一パターン。                       
   
  ユーザーへの動作変化                                                                                                                                                                                                                        
                                                                                                                    
                                                                                             
| シナリオ | 結果 |
|---|---|
| Owner が member を owner に昇格 | ✅ 成功 |
| Owner が他の owner を member に降格（owner 複数いる時） | ✅ 成功 |
| 唯一の owner が自分を member に降格 | ❌ 「役割を変更するには、別のメンバーをオーナーに指定してください」 |
| Member が自己脱退 | ✅ 成功、mypage へ |
| Owner が自己脱退（owner 複数） | ✅ 成功 |
| 唯一の owner が自己脱退 | ❌ 「最後のオーナーが脱退するには、別のメンバーをオーナーに指定してください」 |
| 非 owner が役割変更 API を直叩き | ❌ NotAuthorized → flash + redirect_back |
  
## テスト計画                                                                                                                                                                                                                                  
                                                                                                                    
  - ローカル動作確認                                                                                                                                                                                                                          
    - 全シナリオ動作確認済み（owner ⇄ member 昇格降格 / 自己脱退 / 最後の owner 保護 / 表示権限）
  - CI通過確認                                                                                                                                                                                               
  - Policy / model spec は次タスクの RSpec セットアップで一括追加予定                                                                                                                                                                         
                                                                                                                                                                                                                                              
 ## 残件・TODO                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                    
  - 次タスク: RSpec セットアップ + Policy / model spec 一括追加 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ファミリーグループ内のメンバーロール管理機能を追加しました。所有者とメンバー間でのロール変更が可能になります。
  * グループからの退出機能を実装しました。
  * 最後の所有者がグループから削除されることを防ぐ保護機能を追加しました。
  * メンバー一覧のUIを改善し、各メンバーに対するアクション操作がより直感的になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->