### PR TITLE
  [Release] 家族グループのメンバーシップ管理 + owner kick

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,7 @@ CI 失敗時は原因を調査・修正してからマージ。
 - **画像は webp で保存:** `Memory` の画像は内部的に webp。表示・配信時も webp 前提
 - **認証ルーティング分岐:** 未ログインは `static_pages#top`、ログイン済みは `dashboard#top`（`authenticated :user do ... end` で分岐）
 - **React の使い所:** SPA ではなく **特定機能（神経衰弱ゲーム）でのみ使用**。通常画面は ERB + Stimulus + Turbo。データ取得は `namespace :api` 配下のコントローラ。安易に React 化せず Hotwire で実装できないか先に検討
+- **認可は Pundit ベース:** Policy + Scope + `authorize` / `policy_scope` で統一。`verify_authorized` 有効化済みで認可漏れを CI で検出。設計判断・公開 vs 機微情報の使い分け・race condition 対策などの詳細は [`docs/pundit-design.md`](docs/pundit-design.md) を参照
 
 ---
 

--- a/app/controllers/family_groups_controller.rb
+++ b/app/controllers/family_groups_controller.rb
@@ -39,11 +39,7 @@ class FamilyGroupsController < ApplicationController
   end
 
   def show
-    # ログインユーザーのグループ内での役割を取得
-    @current_membership = @family_group.user_family_groups.find_by(user: current_user)
-    # オーナーかどうかを判定し、ビュー側で条件分岐できるようにインスタンス変数にセット
-    @is_owner = @current_membership&.owner?
-    # 最新の招待リンクを取得（存在する場合）
+    # 最新の招待リンクを取得（存在する場合）。owner 判定は view 側で policy(...) を用いる。
     @latest_invitation = @family_group.invitations.where("expires_at > ?", Time.current).order(created_at: :desc).first
   end
 

--- a/app/controllers/user_family_groups_controller.rb
+++ b/app/controllers/user_family_groups_controller.rb
@@ -22,12 +22,15 @@ class UserFamilyGroupsController < ApplicationController
     end
   end
 
-  # 自分自身の脱退のみ対象（owner kick は本機能では扱わない）。
-  # current_user.user_family_groups で取得することで他人のメンバーシップ削除を弾く。
-  # update と同様に family_group 行をロックして同時脱退の race condition を防ぐ。
+  # 自己脱退（self-leave）と owner による他メンバー除名（owner kick）の両方を扱う。
+  # 取得元はグループ全体に広げ、実権限判定は authorize（destroy?）で行う。
+  # update と同様に family_group 行をロックして同時操作の race condition を防ぐ。
   def destroy
-    @membership = current_user.user_family_groups.find(params[:id])
+    @membership = @family_group.user_family_groups.find(params[:id])
     authorize @membership
+
+    leaving_self = (@membership.user_id == current_user.id)
+    target_name = @membership.user.name
 
     succeeded = false
     ActiveRecord::Base.transaction do
@@ -36,7 +39,11 @@ class UserFamilyGroupsController < ApplicationController
     end
 
     if succeeded
-      redirect_to mypage_path, notice: t("mypage.family_group.show.left_group")
+      if leaving_self
+        redirect_to mypage_path, notice: t("mypage.family_group.show.left_group")
+      else
+        redirect_to @family_group, notice: t("mypage.family_group.show.kicked_member", name: target_name)
+      end
     else
       redirect_to @family_group, alert: @membership.errors.full_messages.to_sentence
     end

--- a/app/controllers/user_family_groups_controller.rb
+++ b/app/controllers/user_family_groups_controller.rb
@@ -1,0 +1,36 @@
+class UserFamilyGroupsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_family_group
+
+  # メンバーの役割変更（owner ⇄ member）。
+  def update
+    @membership = @family_group.user_family_groups.find(params[:id])
+    authorize @membership
+
+    if @membership.update(role: params[:role])
+      redirect_to @family_group, notice: t("mypage.family_group.show.role_updated")
+    else
+      redirect_to @family_group, alert: @membership.errors.full_messages.to_sentence
+    end
+  end
+
+  # 自分自身の脱退のみ対象（owner kick は本機能では扱わない）。
+  # current_user.user_family_groups で取得することで他人のメンバーシップ削除を弾く。
+  def destroy
+    @membership = current_user.user_family_groups.find(params[:id])
+    authorize @membership
+
+    if @membership.destroy
+      redirect_to mypage_path, notice: t("mypage.family_group.show.left_group")
+    else
+      redirect_to @family_group, alert: @membership.errors.full_messages.to_sentence
+    end
+  end
+
+  private
+
+  # 非メンバーには 404（存在隠蔽）、メンバー以上には authorize で操作種別を判定する二段防衛。
+  def set_family_group
+    @family_group = policy_scope(FamilyGroup).find_by!(uuid: params[:family_group_uuid])
+  end
+end

--- a/app/controllers/user_family_groups_controller.rb
+++ b/app/controllers/user_family_groups_controller.rb
@@ -3,11 +3,19 @@ class UserFamilyGroupsController < ApplicationController
   before_action :set_family_group
 
   # メンバーの役割変更（owner ⇄ member）。
+  # family_group 行を pessimistic lock することで、同時に複数の owner を
+  # member に降格して owner が 0 人になる race condition を防ぐ。
   def update
     @membership = @family_group.user_family_groups.find(params[:id])
     authorize @membership
 
-    if @membership.update(role: params[:role])
+    succeeded = false
+    ActiveRecord::Base.transaction do
+      @family_group.lock!
+      succeeded = @membership.update(role: params[:role])
+    end
+
+    if succeeded
       redirect_to @family_group, notice: t("mypage.family_group.show.role_updated")
     else
       redirect_to @family_group, alert: @membership.errors.full_messages.to_sentence
@@ -16,11 +24,18 @@ class UserFamilyGroupsController < ApplicationController
 
   # 自分自身の脱退のみ対象（owner kick は本機能では扱わない）。
   # current_user.user_family_groups で取得することで他人のメンバーシップ削除を弾く。
+  # update と同様に family_group 行をロックして同時脱退の race condition を防ぐ。
   def destroy
     @membership = current_user.user_family_groups.find(params[:id])
     authorize @membership
 
-    if @membership.destroy
+    succeeded = false
+    ActiveRecord::Base.transaction do
+      @family_group.lock!
+      succeeded = @membership.destroy
+    end
+
+    if succeeded
       redirect_to mypage_path, notice: t("mypage.family_group.show.left_group")
     else
       redirect_to @family_group, alert: @membership.errors.full_messages.to_sentence

--- a/app/models/user_family_group.rb
+++ b/app/models/user_family_group.rb
@@ -5,4 +5,31 @@ class UserFamilyGroup < ApplicationRecord
   enum :role, { owner: 0, member: 1 }  # defaultはmember
 
   validates :user_id, uniqueness: { message: "は1つの家族グループにしか所属できません" }
+
+  # 最後のオーナーが member に降格されないようにする（操作後に owner が 0 人になる変更を弾く）。
+  validate :must_keep_at_least_one_owner_after_demotion, on: :update
+
+  # 最後のオーナーが脱退できないようにする。
+  before_destroy :ensure_at_least_one_owner_remains_after_leave
+
+  private
+
+  def must_keep_at_least_one_owner_after_demotion
+    return unless role_changed? && role_was == "owner"
+    return if other_owners_exist?
+
+    errors.add(:role, "を変更するには、別のメンバーをオーナーに指定してください")
+  end
+
+  def ensure_at_least_one_owner_remains_after_leave
+    return unless owner?
+    return if other_owners_exist?
+
+    errors.add(:base, "最後のオーナーが脱退するには、別のメンバーをオーナーに指定してください")
+    throw :abort
+  end
+
+  def other_owners_exist?
+    family_group.user_family_groups.where(role: :owner).where.not(id: id).exists?
+  end
 end

--- a/app/models/user_family_group.rb
+++ b/app/models/user_family_group.rb
@@ -2,7 +2,9 @@ class UserFamilyGroup < ApplicationRecord
   belongs_to :user
   belongs_to :family_group
 
-  enum :role, { owner: 0, member: 1 }  # defaultはmember
+  # validate: true により、enum に存在しない値の代入で ArgumentError を発生させる代わりに
+  # validation エラーとして扱う（params 経由で来る不正値で 500 になるのを防ぐ）。
+  enum :role, { owner: 0, member: 1 }, validate: true  # defaultはmember
 
   validates :user_id, uniqueness: { message: "は1つの家族グループにしか所属できません" }
 

--- a/app/policies/user_family_group_policy.rb
+++ b/app/policies/user_family_group_policy.rb
@@ -6,6 +6,10 @@ class UserFamilyGroupPolicy < ApplicationPolicy
   def update?  = group_owner?
   def destroy? = self_membership? || group_owner?
 
+  # 「自分自身の脱退」の可否（view のボタン表示判定で使用）。
+  # destroy? は owner kick も許可する permissive な定義のため、自己脱退の表示判定は分離する。
+  def leave? = self_membership?
+
   # 自分が属するグループのメンバーシップのみ可視。
   class Scope < ApplicationPolicy::Scope
     def resolve

--- a/app/policies/user_family_group_policy.rb
+++ b/app/policies/user_family_group_policy.rb
@@ -10,6 +10,10 @@ class UserFamilyGroupPolicy < ApplicationPolicy
   # destroy? は owner kick も許可する permissive な定義のため、自己脱退の表示判定は分離する。
   def leave? = self_membership?
 
+  # 「他のメンバーを除名する」の可否（view の除名ボタンの表示判定で使用）。
+  # destroy? を流用すると自分自身の行にも除名ボタンが出てしまうため、自分以外の行に限定する。
+  def kick? = group_owner? && !self_membership?
+
   # 自分が属するグループのメンバーシップのみ可視。
   class Scope < ApplicationPolicy::Scope
     def resolve

--- a/app/views/family_groups/show.html.erb
+++ b/app/views/family_groups/show.html.erb
@@ -26,16 +26,44 @@
 
         <ul class="flex flex-col gap-3">
           <% @family_group.user_family_groups.includes(:user).each do |ufg| %>
-            <li class="flex items-center justify-between">
+            <li class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
               <div class="flex items-center gap-3">
                 <%= render "shared/user_avatar", user: ufg.user, size: :md %>
                 <span class="text-sm font-medium"><%= ufg.user.name %></span>
+                <% if ufg.owner? %>
+                  <span class="badge badge-primary badge-sm"><%= t('mypage.family_group.owner_badge') %></span>
+                <% else %>
+                  <span class="badge badge-ghost badge-sm"><%= t('mypage.family_group.member_badge') %></span>
+                <% end %>
               </div>
-              <% if ufg.owner? %>
-                <span class="badge badge-primary badge-sm"><%= t('mypage.family_group.owner_badge') %></span>
-              <% else %>
-                <span class="badge badge-ghost badge-sm"><%= t('mypage.family_group.member_badge') %></span>
-              <% end %>
+
+              <div class="flex flex-wrap items-center gap-2">
+                <% if policy(ufg).update? %>
+                  <% if ufg.member? %>
+                    <%= button_to t('mypage.family_group.show.promote_to_owner'),
+                                  family_group_user_family_group_path(@family_group, ufg),
+                                  method: :patch,
+                                  params: { role: "owner" },
+                                  data: { turbo_confirm: t('mypage.family_group.show.promote_confirm') },
+                                  class: "btn btn-xs btn-outline btn-primary" %>
+                  <% else %>
+                    <%= button_to t('mypage.family_group.show.demote_to_member'),
+                                  family_group_user_family_group_path(@family_group, ufg),
+                                  method: :patch,
+                                  params: { role: "member" },
+                                  data: { turbo_confirm: t('mypage.family_group.show.demote_confirm') },
+                                  class: "btn btn-xs btn-outline" %>
+                  <% end %>
+                <% end %>
+
+                <% if policy(ufg).leave? %>
+                  <%= button_to t('mypage.family_group.show.leave_group'),
+                                family_group_user_family_group_path(@family_group, ufg),
+                                method: :delete,
+                                data: { turbo_confirm: t('mypage.family_group.show.leave_confirm') },
+                                class: "btn btn-xs btn-outline btn-error" %>
+                <% end %>
+              </div>
             </li>
           <% end %>
         </ul>
@@ -43,7 +71,7 @@
     </div>
 
 
-    <% if @is_owner %>
+    <% if policy(@family_group).update? %>
       <!-- オーナーのみ招待リンク発行ボタンを表示 -->
       <div class="card bg-base-100 shadow-2xl border border-base-200">
         <div class="card-body p-6 gap-4">
@@ -87,7 +115,7 @@
         <%= t('mypage.family_group.show.return_to_mypage') %>
       <% end %>
 
-      <% if @is_owner %>
+      <% if policy(@family_group).destroy? %>
         <%= link_to family_group_path(@family_group),
               data: { turbo_method: :delete, turbo_confirm: "グループを解散しますか？この操作は取り消せません。" },
               class: "btn btn-error btn-outline btn-sm gap-2" do %>

--- a/app/views/family_groups/show.html.erb
+++ b/app/views/family_groups/show.html.erb
@@ -63,6 +63,14 @@
                                 data: { turbo_confirm: t('mypage.family_group.show.leave_confirm') },
                                 class: "btn btn-xs btn-outline btn-error" %>
                 <% end %>
+
+                <% if policy(ufg).kick? %>
+                  <%= button_to t('mypage.family_group.show.kick_member'),
+                                family_group_user_family_group_path(@family_group, ufg),
+                                method: :delete,
+                                data: { turbo_confirm: t('mypage.family_group.show.kick_confirm', name: ufg.user.name) },
+                                class: "btn btn-xs btn-outline btn-error" %>
+                <% end %>
               </div>
             </li>
           <% end %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -15,6 +15,8 @@ ja:
         memory_date: 思い出の日付
         visibility: 公開範囲
         image: 画像
+      user_family_group:
+        role: 役割
   enums:
     memory:
       visibility:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -96,11 +96,14 @@ ja:
         promote_to_owner: オーナーにする
         demote_to_member: メンバーにする
         leave_group: グループから脱退する
+        kick_member: 除名する
         promote_confirm: このメンバーをオーナーにしますか？
         demote_confirm: このメンバーをメンバーに変更しますか？
         leave_confirm: グループから脱退しますか？
+        kick_confirm: "%{name}さんを除名しますか？"
         role_updated: メンバーの役割を更新しました
         left_group: グループから脱退しました
+        kicked_member: "%{name}さんを除名しました"
   invitation:
     show:
       title: グループへの招待

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -93,6 +93,14 @@ ja:
         generate_invitation: 招待リンクを発行する
         return_to_mypage: マイページに戻る
         disband_group: グループを解散する
+        promote_to_owner: オーナーにする
+        demote_to_member: メンバーにする
+        leave_group: グループから脱退する
+        promote_confirm: このメンバーをオーナーにしますか？
+        demote_confirm: このメンバーをメンバーに変更しますか？
+        leave_confirm: グループから脱退しますか？
+        role_updated: メンバーの役割を更新しました
+        left_group: グループから脱退しました
   invitation:
     show:
       title: グループへの招待

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,10 @@ Rails.application.routes.draw do
   resources :public_memories, param: :uuid, only: %i[index show]
 
   # 家族グループ - uuidをURLパラメータとして使用するため、param: :uuidを指定
-  resources :family_groups, param: :uuid, only: %i[new create update show destroy]
+  resources :family_groups, param: :uuid, only: %i[new create update show destroy] do
+    # メンバーシップ操作（役割変更・脱退）。member 中間テーブルのため id は数値 ID。
+    resources :user_family_groups, only: %i[update destroy]
+  end
 
   get "memory_game" => "memory_games#show", as: :memory_game
 

--- a/docs/pundit-design.md
+++ b/docs/pundit-design.md
@@ -1,0 +1,204 @@
+# Pundit 認可基盤 設計メモ
+
+ミニメモリー（Rails 7.2 / Pundit）における認可基盤の構成と、設計上の判断を記録する。
+
+---
+
+## 段階導入
+
+| 順 | PR | 内容 |
+|---|---|---|
+| 1 | #206 | gem 追加 + ApplicationController 認可基盤 |
+| 2 | #208 | 各 Policy + Scope（コントローラ未適用） |
+| 3 | #209 | MemoriesController に Pundit 適用 |
+| 4 | #211 | FamilyGroupsController に Pundit 適用 |
+| 5 | #212 | InvitationsController に Pundit 適用 |
+| 6 | #213 | Dashboard / Api::MemoryGames で `policy_scope` 適用 |
+| 7 | #215 | `verify_authorized` 有効化 |
+| 8 | #218 | メンバーシップ管理（役割変更 / 自己脱退 / owner kick） |
+
+各 PR を develop に積み、揃った後 main に一斉リリース。
+
+---
+
+## 核心となる設計判断
+
+### 1. 認可呼び出しのパターン
+
+本コードベースでは以下の 2 つだけを使用:
+
+- `authorize @record` — 単一レコードへの操作可否。`authorize` を呼ぶ時点でメモリ上にインスタンスがあれば良く、DB 保存前の `Memory.new` / `current_user.memories.build(params)` も含む。Policy のメソッドは `record.user_id == user.id` のように属性を参照できる。
+- `policy_scope(Model)` — index 等の一覧アクションで集合を絞り込む。
+
+`authorize Model`（クラス渡し）は本コードベースでは使っていない。
+
+例（`MemoriesController`）:
+```ruby
+def index
+  @my_memories = policy_scope(Memory).with_attached_image.order(...)  # ← 一覧
+end
+
+def new
+  @memory = Memory.new
+  authorize @memory                                                    # ← インスタンス渡し
+end
+
+def create
+  @memory = current_user.memories.build(memory_params)
+  authorize @memory                                                    # ← 属性付きインスタンス
+end
+
+def set_memory
+  @memory = Memory.find_by!(uuid: params[:uuid])
+  authorize @memory                                                    # ← DB から取得したインスタンス
+end
+```
+
+### 2. 公開情報 vs 機微情報
+
+リソースごとに「存在自体を漏らしてよいか」で `set_xxx` のパターンを使い分けた。
+
+| リソース | パターン | 非対象アクセス時の応答 |
+|---|---|---|
+| Memory | `Memory.find_by!(uuid:) + authorize` | 403 相当（`Pundit::NotAuthorizedError` → flash + redirect_back） |
+| FamilyGroup | `policy_scope(FamilyGroup).find_by!(uuid:) + authorize`（**二段防衛**） | 404（`policy_scope` が空 → `find_by!` で `RecordNotFound`） |
+
+実装根拠:
+- `MemoriesController#set_memory`: `Memory.find_by!(uuid:); authorize @memory`
+- `FamilyGroupsController#set_family_group`: `policy_scope(FamilyGroup).find_by!(uuid:); authorize @family_group`
+- `UserFamilyGroupsController#set_family_group`: `policy_scope(FamilyGroup).find_by!(uuid: params[:family_group_uuid])`（こちらは `authorize` を別途各アクションで呼ぶ）
+
+Memory には公開フィード（`PublicMemoriesController`）があるため非所有者の直叩きで 403 を返しても「存在自体」は機微にならない。FamilyGroup は非メンバーに存在を見せない方針なので 404 にする。
+
+### 3. Pundit を経由しないコントローラ
+
+以下は `skip_after_action :verify_authorized` で意図的に `authorize` 呼び出しを免除している:
+
+| コントローラ / アクション | スキップ理由（コードコメントより） |
+|---|---|
+| `MemoriesController#index` | `policy_scope` のみで `authorize` を呼ばないため |
+| `InvitationsController#show` | token 検証のみで Pundit を経由しない設計 |
+| `DashboardController` 全体 | `policy_scope` のみで `authorize` を呼ばない |
+| `Api::MemoryGamesController` 全体 | 同上 |
+| `MypagesController` 全体 | 自分自身のプロフィール表示のため認可不要 |
+| `MemoryGamesController` 全体 | ゲーム画面の表示のみで認可対象レコードが無い |
+| `StaticPagesController` 全体 | 未認証ランディング |
+| `PublicMemoriesController` 全体 | 公開情報（`Memory.publicly_available` を直接使用） |
+
+Devise 系コントローラは `ApplicationController` の `after_action :verify_authorized, unless: :devise_controller?` で一括除外。
+
+### 4. 認可とビジネスルールの分離
+
+`UserFamilyGroup` モデルの「最後の owner 保護」は Policy ではなく **モデル層の validation / before_destroy** で実装している:
+
+```ruby
+# app/models/user_family_group.rb
+validate :must_keep_at_least_one_owner_after_demotion, on: :update
+before_destroy :ensure_at_least_one_owner_remains_after_leave
+```
+
+| レイヤ | 責務 |
+|---|---|
+| Pundit Policy | 「このユーザーがこの操作を実行できるか」 |
+| model validation / before_destroy | 「この変更は不変条件を保てるか」 |
+
+これにより、コントローラ以外の経路（rails console など）からも整合性が守られる。
+
+### 5. ビューの Policy 一元化
+
+ビューでは `policy(record).action?` を直接呼ぶ。コントローラに `@is_owner` のような真偽値を入れるインスタンス変数を作っていない。
+
+実装根拠（`app/views/family_groups/show.html.erb`）:
+- 招待リンク発行カードの表示判定: `<% if policy(@family_group).update? %>`
+- 解散ボタンの表示判定: `<% if policy(@family_group).destroy? %>`
+- 役割変更ボタンの表示判定: `<% if policy(ufg).update? %>`
+- 自己脱退ボタンの表示判定: `<% if policy(ufg).leave? %>`
+- 除名ボタンの表示判定: `<% if policy(ufg).kick? %>`
+
+`FamilyGroupsController#show` も `@is_owner` / `@current_membership` を設定していない（`@latest_invitation` のみ）。
+
+### 6. 並行制御（コントローラ層で `lock!`）
+
+`UserFamilyGroupsController#update` / `#destroy` は `transaction { @family_group.lock!; ... }` で family_group 行を pessimistic lock している:
+
+```ruby
+def update
+  @membership = @family_group.user_family_groups.find(params[:id])
+  authorize @membership
+
+  succeeded = false
+  ActiveRecord::Base.transaction do
+    @family_group.lock!
+    succeeded = @membership.update(role: params[:role])
+  end
+  ...
+end
+```
+
+ロック対象が family_group 行である理由: 同一グループへのメンバー変更は **同じ family_group 行** を介して直列化される。各トランザクションが「異なる owner 行」を個別にロックしても両者は競合せず race condition は解決しないため、グループ単位でロックしている。
+
+なお model の validation / before_destroy 自体は `lock!` を呼ばない（純粋な存在判定のみ）。
+
+### 7.　寛容な権限述語と狭い表示述語
+
+`UserFamilyGroupPolicy` は `destroy?` を **広く** 定義し、view 用に **狭い** 述語を別途用意している:
+
+```ruby
+def destroy? = self_membership? || group_owner?    # アクション認可（self-leave + owner kick 両方を許可）
+def leave?   = self_membership?                    # 自己脱退ボタン表示
+def kick?    = group_owner? && !self_membership?   # 除名ボタン表示
+```
+
+`leave?` と `kick?` は条件が互いに排他的（どちらか片方しか true にならない）。`destroy?` をビューでそのまま使うと、self の行で `self_membership?` が true、かつ owner なら `group_owner?` も true になり、自分自身の行に「除名」ボタンが出てしまうため、表示判定だけは狭い述語を使う。
+
+`UserFamilyGroupsController#destroy` は `authorize @membership` で `destroy?` を経由する。leaving_self（`@membership.user_id == current_user.id`）かどうかで成功時の redirect 先を分岐:
+- self-leave 時 → `mypage_path`
+- owner kick 時 → `family_group_path`
+
+---
+
+## `verify_authorized`
+
+`ApplicationController`:
+
+```ruby
+after_action :verify_authorized, unless: :devise_controller?
+```
+
+各アクションで `authorize` が呼ばれていない場合、Pundit が `Pundit::AuthorizationNotPerformedError` を発生させる。`Pundit::NotAuthorizedError`（実行時の認可拒否）とは別の例外で、認可呼び忘れの検出に使う。
+
+`verify_policy_scoped` は導入していない。
+
+---
+
+## トレードオフ
+
+- **未認可メッセージの汎用化**: `config/locales/pundit.ja.yml` は `not_authorized: 操作する権限がありません` のみ。Pundit 導入前に `FamilyGroupsController#destroy` 内に書かれていた「家族グループの削除はオーナーのみ可能です」のようなアクション固有のメッセージは、認可拒否経路では出なくなった。
+- **早期ブロック**: 既所属ユーザーが `/family_groups/new` を開いた時点で `FamilyGroupPolicy#new?`（`= create?`）が `user.user_family_groups.empty?` を返さず `Pundit::NotAuthorizedError` で弾かれる。`/family_groups` への POST 時の `RecordNotUnique` rescue も残してあるが、UI フロー上はそこに到達しない。
+
+---
+
+## ファイル構成
+
+```
+app/policies/
+├── application_policy.rb       基底クラス（全述語デフォルト false / Scope#resolve は NoMethodError）
+├── memory_policy.rb
+├── family_group_policy.rb
+├── user_family_group_policy.rb
+└── invitation_policy.rb
+
+app/controllers/application_controller.rb  # Pundit::Authorization include / verify_authorized / NotAuthorizedError 捕捉
+config/locales/pundit.ja.yml                # 未認可メッセージ I18n
+```
+
+---
+
+## 今後の判断のためのデフォルト原則
+
+1. 新規モデル → **Policy + Scope を最初に書く**（コントローラ適用は後でも可）
+2. **「機微 vs 公開」を最初に判断** → 機微なら二段防衛
+3. **認可（誰が）かビジネスルール（整合性）か** を意識してレイヤを選ぶ
+4. **ビューでは `policy(...)` を直接呼ぶ**。コントローラに `@is_xxx` ivar を作らない
+5. **並行性が重要な操作** はコントローラ層で `transaction { lock!; ... }`
+6. **Pundit を通さない判断** をする時は `skip_after_action :verify_authorized` で意図を明示


### PR DESCRIPTION
 ## 概要                                                                                                                                                                                                                                     
  家族グループのメンバーシップ管理機能を main に反映。owner / member の役割変更、自己脱退、owner による他メンバー除名（owner kick）の各操作と、それらを支える「最後の owner 保護」「Pundit Policy 一元化」「pessimistic lock              
  による並行制御」「`validate: true` による不正値ハンドリング」を含む。                                                                                                                                                                       
                                                                                                                                                                                                                                              
  併せて、Pundit 認可基盤の設計メモ（`docs/pundit-design.md`）を追加。
                                                                                                                                                                                                                                              
  ## 含まれるマージ済み PR                                                                                                                                                                                                                  
  1. #218 [Feature] 家族グループのメンバーシップ管理機能を追加                                                                                                                                                                                
     - 役割変更（owner ⇄ member）/ 自己脱退 / 最後の owner 保護
     - ビューの Policy 一元化（`@is_owner` 撤廃 → `policy(...).action?`）                                                                                                                                                                     
     - CodeRabbit 指摘対応: `enum :role, validate: true`、controller 層での `transaction { @family_group.lock!; ... }`                                                                                                                        
  2. #220 [Feature] owner kick 機能 + Pundit 設計メモ                                                                                                                                                                                         
     - owner が他メンバーを除名できる機能                                                                                                                                                                                                     
     - `UserFamilyGroupPolicy#kick?` 追加（`destroy?` は permissive のまま、view 用に狭い述語を分離）                                                                                                                                         
     - `docs/pundit-design.md` 追加 / `CLAUDE.md` から参照                                                                                                                                                                                    
                                                                                                                                                                                                                                              
  ## 主な変更ファイル                                                                                                                                                                                                                         
  | 区分 | ファイル | 内容 |                                                                                                                                                                                                                  
  |---|---|---|                                                                                                     
  | 新規 controller | `app/controllers/user_family_groups_controller.rb` | 役割変更 / 脱退 / 除名 |                                                                                                                                           
  | Policy | `app/policies/user_family_group_policy.rb` | `leave?` / `kick?` 追加 |                                 
  | Model | `app/models/user_family_group.rb` | `enum validate: true` / 最後の owner 保護 (validation + before_destroy) |                                                                                                                     
  | Controller | `app/controllers/family_groups_controller.rb` | `@is_owner` / `@current_membership` 撤廃 |              
  | View | `app/views/family_groups/show.html.erb` | メンバー操作 UI 追加、Policy ベースの判定 |                                                                                                                                              
  | Routes | `config/routes.rb` | `family_groups` 配下に `user_family_groups` を nest |                                                                                                                                                       
  | i18n | `config/locales/activerecord/ja.yml` / `config/locales/views/ja.yml` | role 属性ラベル + 操作文言 |                                                                                                                                
  | Docs | `docs/pundit-design.md` | Pundit 認可基盤の設計メモ |                                                                                                                                                                              
  | Docs | `CLAUDE.md` | 設計メモへの参照を追加 |                                                                                                                                                                                             
                                                                                                                                                                                                                                              
  ## 設計の重要ポイント                                                                                                                                                                                                                       
                                                                                                                                                                                                                                              
  ### 認可とビジネスルールのレイヤ分離                                                                                                                                                                                                        
  - **Pundit Policy**:「誰がこの操作を実行できるか」                                                                                                                                                                                          
  - **Model validation / before_destroy**:「データが整合性を保てるか」（最後の owner 保護）                         
                                                                                                                                                                                                                                              
  ### ビューの Policy 一元化                                                                                                                                                                                                                  
  ```erb                                                                                                                                                                                                                                      
  # Before                # After                                                                                                                                                                                                             
  <% if @is_owner %>      <% if policy(@family_group).update? %>     
```                                               
  コントローラの owner 判定 ivar を撤廃し、view 内で直接 policy(...).action? を呼ぶ構成。                                                                                                                                                     
                                                                                                                                                                                                                                              
  ### 並行制御（pessimistic lock）                                                                                                                                                                                                                
                                                                                                                                                                                                                                              
  UserFamilyGroupsController#update / #destroy を transaction { @family_group.lock!; ... } で包み、同一グループへの並行変更を直列化。最後の owner 保護が race condition で破れないよう担保。                                                  
                                                                                                                    
  ### 寛容な権限述語と狭い表示述語の分離                                                                                                                                                                                                          
                                                                                                                    
  - destroy? = self_membership? || group_owner? ← アクション認可（self-leave + owner kick 両方を許可）                                                                                                                                        
  - leave? = self_membership? ← 自己脱退ボタン表示                                                                  
  - kick? = group_owner? && !self_membership? ← 除名ボタン表示                                                                                                                                                                                
  view にそのまま destroy? を使うと自分自身の行にも除名ボタンが出てしまうため、表示判定だけ狭い述語を使う。                                                                                                                                   
                                                                                                                                                                                                                                              
 ## ユーザーへの動作変化
 | シナリオ | 結果 |
|---|---|
| owner が member を owner に昇格 / 降格 | ✅ 成功 |
| 唯一の owner が自身を member に降格 / 自己脱退 | ❌ 「別のメンバーをオーナーに指定してください」 |
| member の自己脱退 | ✅ mypage へリダイレクト |
| owner が他メンバーを除名 | ✅ family_group 画面に「○○ さんを除名しました」 |
| 不正な role 値が POST された場合 | 422 相当（500 にならない、validate: true で吸収） |
| 並行で 2 owner が互いに demote/leave/kick を試行 | lock! で直列化され、後発側が「最後の owner 保護」で弾かれる |