### PR TITLE
Memory#visibility の unlisted を有効化

### DIFF
--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -16,8 +16,8 @@ class Memory < ApplicationRecord
   # enum公開範囲定義
   enum :visibility, {
     private_only: 0,   # 本人のみ閲覧可能
-    # unlisted: 1,  # 家族グループメンバーのみ閲覧可能
-    published: 2     # 掲示板にて誰でも閲覧可能、非公開URLを知っている人も閲覧可能
+    unlisted: 1,       # 家族グループメンバーのみ閲覧可能
+    published: 2       # 掲示板にて誰でも閲覧可能、非公開URLを知っている人も閲覧可能
   }
 
   # 公開投稿のみを取得するスコープ

--- a/app/policies/memory_policy.rb
+++ b/app/policies/memory_policy.rb
@@ -5,7 +5,7 @@
 # PublicMemoriesController は公開情報を扱うため Pundit を経由しない設計（Memory.publicly_available を直接使用）。
 class MemoryPolicy < ApplicationPolicy
   def index?   = true
-  def show?    = record.published? || owner?
+  def show?    = record.published? || owner? || (record.unlisted? && family_member_of_owner?)
   def create?  = user.present?
   def update?  = owner?
   def destroy? = owner?
@@ -22,5 +22,12 @@ class MemoryPolicy < ApplicationPolicy
   def owner?
     return false if user.nil?
     record.user_id == user.id
+  end
+
+  # current_user の所属家族グループと record.user の所属家族グループに重複があるか。
+  # 「1 ユーザー 1 グループ」制約下では、実質「同じ家族グループに属しているか」の判定。
+  def family_member_of_owner?
+    return false if user.nil?
+    user.family_groups.where(id: record.user.family_groups.select(:id)).exists?
   end
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -21,5 +21,5 @@ ja:
     memory:
       visibility:
         private_only: 非公開
-        # unlisted: 家族グループメンバーのみ閲覧可能
+        unlisted: 家族グループメンバーのみ閲覧可能
         published: 掲示板にて誰でも閲覧可能


### PR DESCRIPTION
## 概要                                                        
  予約済みだった `Memory#visibility` の `unlisted: 1`（家族グループメンバーのみ閲覧可能）を有効化する。所有者と「同じ家族グループのメンバー」が閲覧できる中間の公開範囲を追加。                                                               
                                                                                                                                                                                                                                            
  家族フィードページ（家族メンバーの memory 一覧）の実装は本 PR ではスコープ外で、続く PR で対応予定。                                                                                                                                        
                                                                                                                                                                                                                                              
  ## 関連 Issue                                                                                                                                                                                                                               
  （家族フィード機能の前段。続く PR で家族フィードページとナビゲーション変更を予定）                                                                                                                                                          
                                                                                                                                                                                                                                            
  ## 変更ファイル一覧                                                                                                                                                                                                                         
  | ファイル | 種別 | 変更理由 |
  |---------|------|---------|                                                                                                                                                                                                                
  | `app/models/memory.rb` | 変更 | enum `:visibility` の `unlisted: 1` のコメントを外して有効化 |                                                                                                                                          
  | `config/locales/activerecord/ja.yml` | 変更 | `enums.memory.visibility.unlisted` の翻訳を有効化 |
  | `app/policies/memory_policy.rb` | 変更 | `show?` を `unlisted` の家族メンバー閲覧条件に対応 |                                                                                                                                             
                                                                                                                                                                                                                                              
  ## 実装のポイント                                                                                                                                                                                                                           
                                                                                                                                                                                                                                              
  ### `MemoryPolicy#show?` の更新                                                                                                                                                                                                             
  ```ruby                                                                                                                                                                                                                                     
  def show? = record.published? || owner? || (record.unlisted? && family_member_of_owner?)
                                                                                                                                                                                                                                              
  private                                                                                                                                                                                                                                     
                                                                 
  def family_member_of_owner?                                                                                                                                                                                                                 
    return false if user.nil?                                                                                       
    user.family_groups.where(id: record.user.family_groups.select(:id)).exists?
  end                                                                          
                   
```
                                                                                                                                                                                                                           
  family_member_of_owner? は subquery で DB 内完結 して判定。pluck + 集合演算ではなく EXISTS 相当の効率的なクエリにする。「1 ユーザー 1 グループ」制約下では、実質「同じ家族グループに属しているか」の判定。                                  
                                                                                                                                                                                                                                              
###  各 visibility の閲覧ルール                                                                                                                                                                                                                  
   | visibility | 値 | 誰が閲覧可？ |
| --- | --- | --- |
| private_only | 0 | 所有者のみ |
| unlisted（今回有効化） | 1 | 所有者 + 所有者と同じ家族グループのメンバー |
| published | 2 | 全員 |                                                                                                                                            
                                                                                                                    
###  Scope は変更しない                                                                                                                                                                                                                          
                                                                                                                    
  MemoryPolicy::Scope#resolve = scope.where(user: user) はそのまま。「自分の投稿一覧（MemoriesController#index）」専用の Scope。家族フィード用は別 PR で FamilyFeedMemoryPolicy::Scope（仮）として新設予定。                                  
   
 ### フォームは自動対応                                                                                                                                                                                                                          
                                                                                                                    
  Memory.visibility_options_for_select が Memory.visibilities.keys を反復して i18n で翻訳を引いているため、enum と i18n のコメントを外すだけで投稿フォームの公開範囲 select に「家族グループメンバーのみ閲覧可能」が自動で追加される。        
   
 ###  既存データ・他コントローラへの影響なし                                                                                                                                                                                                      
                                                                                                                    
  - DB の visibility カラムには 0 / 2 の値しか入っていない（1 は予約状態だった）。enum を有効化しても既存データは変更されない                                                                                                                 
  - PublicMemoriesController は Memory.publicly_available（= where(visibility: :published)）を使うため unlisted は混入しない
  - DashboardController#top の policy_scope(Memory) は user 一致で絞るため、自分の unlisted 投稿は含まれる（仕様通り）                                                                                                                        
                                                                                                                                                                                                                                              
### ユーザーへの動作変化     
| シナリオ | 結果 |
| --- | --- |
| 新規投稿フォームの公開範囲 select | 3 件（非公開 / 家族グループメンバーのみ閲覧可能 / 掲示板にて誰でも閲覧可能） |
| 同じ家族グループのメンバーが他人の unlisted memory uuid を直叩き | 表示される |
| 別グループ / 未所属ユーザーが他人の unlisted memory uuid を直叩き | flash「操作する権限がありません」+ redirect_back |
| /public_memories | unlisted は混入しない（従来通り） |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * メモリーに新しい公開設定「ファミリーグループメンバーのみ閲覧可能」を追加しました。同じファミリーグループに属するメンバーのみがメモリーを閲覧・共有できるようになり、より柔軟なプライバシー管理が実現しました。日本語に対応しています。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tantp-1111/mini_memory/pull/223)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->