### PR TITLE
 [Release] 家族のミニメモリ一覧ページ追加と Memory#unlisted 有効化を main へ反映

### DIFF
--- a/app/controllers/family_memories_controller.rb
+++ b/app/controllers/family_memories_controller.rb
@@ -1,0 +1,13 @@
+class FamilyMemoriesController < ApplicationController
+  before_action :authenticate_user!
+  # policy_scope のみで authorize を呼ばないため verify_authorized を除外。
+  skip_after_action :verify_authorized
+
+  def index
+    @memories = policy_scope(Memory, policy_scope_class: FamilyFeedMemoryPolicy::Scope)
+                  .with_attached_image
+                  .includes(:user)
+                  .order(created_at: :desc)
+    @has_family_group = current_user.family_groups.exists?
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,4 +58,9 @@ module ApplicationHelper
   def active_if_memories_new
     action_name.in?(%w[new create]) ? active_if("memories") : ""
   end
+
+  # 新規投稿 FAB の表示可否。memory の投稿フォーム関連アクションでは出さない。
+  def show_new_memory_fab?
+    !(controller_name == "memories" && action_name.in?(%w[new create edit update]))
+  end
 end

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -16,8 +16,8 @@ class Memory < ApplicationRecord
   # enum公開範囲定義
   enum :visibility, {
     private_only: 0,   # 本人のみ閲覧可能
-    # unlisted: 1,  # 家族グループメンバーのみ閲覧可能
-    published: 2     # 掲示板にて誰でも閲覧可能、非公開URLを知っている人も閲覧可能
+    unlisted: 1,       # 家族グループメンバーのみ閲覧可能
+    published: 2       # 掲示板にて誰でも閲覧可能、非公開URLを知っている人も閲覧可能
   }
 
   # 公開投稿のみを取得するスコープ

--- a/app/policies/family_feed_memory_policy.rb
+++ b/app/policies/family_feed_memory_policy.rb
@@ -1,0 +1,20 @@
+# 家族フィード（FamilyMemoriesController#index）専用の Scope を提供する Policy。
+#
+# MemoryPolicy::Scope は「自分の投稿のみ」を返すため、家族メンバー横断の集合は
+# 別 Scope として責務を分離する。コントローラ側で
+# policy_scope(Memory, policy_scope_class: FamilyFeedMemoryPolicy::Scope) と
+# 明示的に指定して呼び出す。
+class FamilyFeedMemoryPolicy < ApplicationPolicy
+  # 自分が所属する家族グループのメンバー（自分含む）が投稿した unlisted / published を返す。
+  # private_only は所有者本人専用なのでフィードからは除外する。
+  # 家族グループ未所属の場合は user.family_groups が空 → 連鎖する subquery が空 → 結果 0 件。
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope.none if user.nil?
+      family_user_ids = UserFamilyGroup
+                          .where(family_group_id: user.family_groups.select(:id))
+                          .select(:user_id)
+      scope.where(user_id: family_user_ids, visibility: [ :unlisted, :published ])
+    end
+  end
+end

--- a/app/policies/memory_policy.rb
+++ b/app/policies/memory_policy.rb
@@ -5,7 +5,7 @@
 # PublicMemoriesController は公開情報を扱うため Pundit を経由しない設計（Memory.publicly_available を直接使用）。
 class MemoryPolicy < ApplicationPolicy
   def index?   = true
-  def show?    = record.published? || owner?
+  def show?    = record.published? || owner? || (record.unlisted? && family_member_of_owner?)
   def create?  = user.present?
   def update?  = owner?
   def destroy? = owner?
@@ -22,5 +22,12 @@ class MemoryPolicy < ApplicationPolicy
   def owner?
     return false if user.nil?
     record.user_id == user.id
+  end
+
+  # current_user の所属家族グループと record.user の所属家族グループに重複があるか。
+  # 「1 ユーザー 1 グループ」制約下では、実質「同じ家族グループに属しているか」の判定。
+  def family_member_of_owner?
+    return false if user.nil?
+    user.family_groups.where(id: record.user.family_groups.select(:id)).exists?
   end
 end

--- a/app/views/dashboard/top.html.erb
+++ b/app/views/dashboard/top.html.erb
@@ -52,18 +52,32 @@
     </section>
 
     <!-- クイックアクセス -->
-    <section class="grid grid-cols-1 md:grid-cols-3 gap-4">
+    <section class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
 
       <%= link_to memories_path, class: "card bg-base-100 shadow-xl hover:shadow-2xl hover:-translate-y-1 transition border-l-4 border-primary" do %>
         <div class="card-body gap-3">
           <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-primary/10 shrink-0 self-start">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-primary fill-current" viewBox="0 -960 960 960">
-              <path d="M480-260q75 0 127.5-52.5T660-440q0-75-52.5-127.5T480-620q-75 0-127.5 52.5T300-440q0 75 52.5 127.5T480-260Zm0-80q-42 0-71-29t-29-71q0-42 29-71t71-29q42 0 71 29t29 71q0 42-29 71t-71 29ZM160-120q-33 0-56.5-23.5T80-200v-480q0-33 23.5-56.5T160-760h126l74-80h240l74 80h126q33 0 56.5 23.5T880-680v480q0 33-23.5 56.5T800-120H160Zm0-80h640v-480H638l-73-80H395l-73 80H160v480Zm320-240Z"/>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-5 w-5 text-primary">
+              <path d="M10.75 16.82A7.462 7.462 0 0 1 15 15.5c.71 0 1.396.098 2.046.282A.75.75 0 0 0 18 15.06v-11a.75.75 0 0 0-.546-.721A9.006 9.006 0 0 0 15 3a8.963 8.963 0 0 0-4.25 1.065V16.82ZM9.25 4.065A8.963 8.963 0 0 0 5 3c-.85 0-1.673.118-2.454.339A.75.75 0 0 0 2 4.06v11a.75.75 0 0 0 .954.721A7.506 7.506 0 0 1 5 15.5c1.579 0 3.042.487 4.25 1.32V4.065Z" />
             </svg>
           </div>
           <div>
             <h2 class="card-title text-base">ミニメモリー一覧</h2>
             <p class="text-sm text-base-content/60 mt-1">自分のミニメモリーを確認できます。</p>
+          </div>
+        </div>
+      <% end %>
+
+      <%= link_to family_memories_path, class: "card bg-base-100 shadow-xl hover:shadow-2xl hover:-translate-y-1 transition border-l-4 border-info" do %>
+        <div class="card-body gap-3">
+          <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-info/10 shrink-0 self-start">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-info" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z" />
+            </svg>
+          </div>
+          <div>
+            <h2 class="card-title text-base">家族のミニメモリ</h2>
+            <p class="text-sm text-base-content/60 mt-1">家族メンバーが共有したミニメモリーを見られます。</p>
           </div>
         </div>
       <% end %>
@@ -85,8 +99,8 @@
       <%= link_to memory_game_path, class: "card bg-base-100 shadow-xl hover:shadow-2xl hover:-translate-y-1 transition border-l-4 border-accent" do %>
         <div class="card-body gap-3">
           <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-accent/10 shrink-0 self-start">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-accent fill-current" viewBox="0 -960 960 960">
-              <path d="M189-160q-60 0-102.5-43T42-307q0-9 1-18t3-18l84-336q14-54 57-87.5t98-33.5h390q55 0 98 33.5t57 87.5l84 336q2 9 3.5 18.5T919-306q0 61-43.5 103.5T771-160q-42 0-78-22t-54-60l-28-58q-5-10-15-15t-21-5H385q-11 0-21 5t-15 15l-28 58q-18 38-54 60t-78 22Zm3-80q19 0 34.5-10t23.5-27l28-57q15-31 44-48.5t63-17.5h190q34 0 63 18t45 48l28 57q8 17 23.5 27t34.5 10q28 0 48-18.5t21-46.5q0 1-2-19l-84-335q-7-27-28-44t-49-17H285q-28 0-49.5 17T208-659l-84 335q-2 6-2 18 0 28 20.5 47t49.5 19Zm376.5-291.5Q580-543 580-560t-11.5-28.5Q557-600 540-600t-28.5 11.5Q500-577 500-560t11.5 28.5Q523-520 540-520t28.5-11.5Zm80-80Q660-623 660-640t-11.5-28.5Q637-680 620-680t-28.5 11.5Q580-657 580-640t11.5 28.5Q603-600 620-600t28.5-11.5Zm0 160Q660-463 660-480t-11.5-28.5Q637-520 620-520t-28.5 11.5Q580-497 580-480t11.5 28.5Q603-440 620-440t28.5-11.5Zm80-80Q740-543 740-560t-11.5-28.5Q717-600 700-600t-28.5 11.5Q660-577 660-560t11.5 28.5Q683-520 700-520t28.5-11.5Zm-367 63Q370-477 370-490v-40h40q13 0 21.5-8.5T440-560q0-13-8.5-21.5T410-590h-40v-40q0-13-8.5-21.5T340-660q-13 0-21.5 8.5T310-630v40h-40q-13 0-21.5 8.5T240-560q0 13 8.5 21.5T270-530h40v40q0 13 8.5 21.5T340-460q13 0 21.5-8.5ZM480-480Z"/>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-accent" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z" />
             </svg>
           </div>
           <div>

--- a/app/views/family_memories/_memory.html.erb
+++ b/app/views/family_memories/_memory.html.erb
@@ -7,7 +7,7 @@
     <div class="px-3 py-2 flex items-center gap-2 mt-1">
       <%= render "shared/user_avatar", user: memory.user, size: :sm %>
       <span class="text-xs text-base-content/60 truncate">
-        <%= memory.user&.name || "不明なユーザー" %>
+        <%= memory.user&.name || t("defaults.unknown_user") %>
       </span>
     </div>
 

--- a/app/views/family_memories/_memory.html.erb
+++ b/app/views/family_memories/_memory.html.erb
@@ -1,0 +1,29 @@
+<div class="masonry-item">
+  <%= link_to memory_path(memory),
+      id: "memory-id-#{memory.id}",
+      class: "bg-base-100 block rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow" do %>
+
+    <!-- ユーザー名 -->
+    <div class="px-3 py-2 flex items-center gap-2 mt-1">
+      <%= render "shared/user_avatar", user: memory.user, size: :sm %>
+      <span class="text-xs text-base-content/60 truncate">
+        <%= memory.user&.name || "不明なユーザー" %>
+      </span>
+    </div>
+
+    <!-- 画像 -->
+    <div class="relative">
+        <%= image_tag memory.display_image,
+            alt: memory.title,
+            class: "w-full object-cover block" %>
+    </div>
+
+    <!-- タイトル -->
+    <div class="px-3 py-2">
+      <p class="font-semibold text-sm text-base-content truncate">
+        <%= memory.title %>
+      </p>
+    </div>
+
+  <% end %>
+</div>

--- a/app/views/family_memories/index.html.erb
+++ b/app/views/family_memories/index.html.erb
@@ -1,0 +1,47 @@
+<div class="max-w-6xl mx-auto px-4 pt-6 pb-24">
+
+  <!-- 背景装飾（家族のミニメモリ: violet + sky - プライベート / 落ち着き） -->
+  <div class="fixed inset-0 overflow-hidden pointer-events-none">
+    <div class="absolute -top-24 -right-24 w-96 h-96 rounded-full opacity-20 bg-violet-400 blur-3xl"></div>
+    <div class="absolute -bottom-24 -left-24 w-96 h-96 rounded-full opacity-20 bg-sky-300 blur-3xl"></div>
+  </div>
+
+  <!-- ヘッダー -->
+  <div class="flex items-center gap-3 mb-6">
+    <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-violet-100 shrink-0">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-violet-500">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z" />
+      </svg>
+    </div>
+    <div>
+      <h1 class="text-xl font-bold tracking-tight leading-tight"><%= t('family_memories.index.title') %></h1>
+      <p class="text-base-content/50 text-xs"><%= t('family_memories.index.subtitle') %></p>
+    </div>
+  </div>
+
+  <% if !@has_family_group %>
+    <!-- 家族グループ未所属 -->
+    <div class="card bg-base-100 shadow-xl border border-base-200">
+      <div class="card-body items-center text-center gap-3 py-12">
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 opacity-30" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z" />
+        </svg>
+        <p class="font-semibold"><%= t('family_memories.index.empty_no_group_title') %></p>
+        <p class="text-sm text-base-content/60"><%= t('family_memories.index.empty_no_group_subtitle') %></p>
+        <%= link_to t('family_memories.index.go_to_mypage'), mypage_path, class: "btn btn-primary btn-sm mt-2" %>
+      </div>
+    </div>
+  <% elsif @memories.blank? %>
+    <!-- 所属しているが投稿なし -->
+    <div class="text-center text-base-content/60 mt-8">
+      <%= t('family_memories.index.empty_no_memories') %>
+    </div>
+  <% else %>
+    <!-- 家族フィード一覧（掲示板と同じカードスタイル） -->
+    <div class="masonry">
+      <%= render partial: "family_memories/memory",
+                 collection: @memories,
+                 as: :memory %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,6 +50,7 @@
       </div>
 
     <%= render 'shared/footer' %>
+    <%= render 'shared/new_memory_fab' %>
 
 
     <!-- jQueryのCDN -->

--- a/app/views/memories/index.html.erb
+++ b/app/views/memories/index.html.erb
@@ -1,12 +1,25 @@
-<div class="max-w-6xl mx-auto px-4 pt-6">
+<div class="max-w-6xl mx-auto px-4 pt-6 pb-24">
 
-  <!-- 背景装飾 -->
+  <!-- 背景装飾（わたしのミニメモリ: rose + amber - 温色 / パーソナル） -->
   <div class="fixed inset-0 overflow-hidden pointer-events-none">
-    <div class="absolute -top-24 -right-24 w-96 h-96 rounded-full opacity-10 bg-primary blur-3xl"></div>
-    <div class="absolute -bottom-24 -left-24 w-96 h-96 rounded-full opacity-10 bg-secondary blur-3xl"></div>
+    <div class="absolute -top-24 -right-24 w-96 h-96 rounded-full opacity-20 bg-rose-400 blur-3xl"></div>
+    <div class="absolute -bottom-24 -left-24 w-96 h-96 rounded-full opacity-20 bg-amber-300 blur-3xl"></div>
   </div>
 
-  <!-- 掲示板一覧 -->
+  <!-- ヘッダー -->
+  <div class="flex items-center gap-3 mb-6">
+    <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-rose-100 shrink-0">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-5 h-5 text-rose-500">
+        <path d="M10.75 16.82A7.462 7.462 0 0 1 15 15.5c.71 0 1.396.098 2.046.282A.75.75 0 0 0 18 15.06v-11a.75.75 0 0 0-.546-.721A9.006 9.006 0 0 0 15 3a8.963 8.963 0 0 0-4.25 1.065V16.82ZM9.25 4.065A8.963 8.963 0 0 0 5 3c-.85 0-1.673.118-2.454.339A.75.75 0 0 0 2 4.06v11a.75.75 0 0 0 .954.721A7.506 7.506 0 0 1 5 15.5c1.579 0 3.042.487 4.25 1.32V4.065Z" />
+      </svg>
+    </div>
+    <div>
+      <h1 class="text-xl font-bold tracking-tight leading-tight"><%= t('memories.index.title') %></h1>
+      <p class="text-base-content/50 text-xs"><%= t('memories.index.subtitle') %></p>
+    </div>
+  </div>
+
+  <!-- ミニメモリ一覧 -->
   <% if @my_memories.present? %>
     <div class="masonry">
       <%= render @my_memories %>

--- a/app/views/public_memories/_memory.html.erb
+++ b/app/views/public_memories/_memory.html.erb
@@ -7,7 +7,7 @@
     <div class="px-3 py-2 flex items-center gap-2 mt-1">
       <%= render "shared/user_avatar", user: memory.user, size: :sm %>
       <span class="text-xs text-base-content/60 truncate">
-        <%= memory.user&.name || "不明なユーザー" %>
+        <%= memory.user&.name || t("defaults.unknown_user") %>
       </span>
     </div>
 

--- a/app/views/public_memories/index.html.erb
+++ b/app/views/public_memories/index.html.erb
@@ -1,5 +1,23 @@
-<div class="min-h-screen bg-base-200">
-<div class="max-w-6xl mx-auto px-4 pt-6">
+<div class="max-w-6xl mx-auto px-4 pt-6 pb-24">
+
+  <!-- 背景装飾（掲示板: emerald + teal - オープン / 爽やか） -->
+  <div class="fixed inset-0 overflow-hidden pointer-events-none">
+    <div class="absolute -top-24 -right-24 w-96 h-96 rounded-full opacity-20 bg-emerald-400 blur-3xl"></div>
+    <div class="absolute -bottom-24 -left-24 w-96 h-96 rounded-full opacity-20 bg-teal-300 blur-3xl"></div>
+  </div>
+
+  <!-- ヘッダー -->
+  <div class="flex items-center gap-3 mb-6">
+    <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-emerald-100 shrink-0">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" class="w-5 h-5 text-emerald-500 fill-current">
+        <path d="M880-80 720-240H320q-33 0-56.5-23.5T240-320v-40h440q33 0 56.5-23.5T760-440v-280h40q33 0 56.5 23.5T880-640v560ZM160-473l47-47h393v-280H160v327ZM80-280v-520q0-33 23.5-56.5T160-880h440q33 0 56.5 23.5T680-800v280q0 33-23.5 56.5T600-440H240L80-280Zm80-240v-280 280Z"/>
+      </svg>
+    </div>
+    <div>
+      <h1 class="text-xl font-bold tracking-tight leading-tight"><%= t('public_memories.index.title') %></h1>
+      <p class="text-base-content/50 text-xs"><%= t('public_memories.index.subtitle') %></p>
+    </div>
+  </div>
 
   <!-- 掲示板一覧 -->
   <% if @public_memories.present? %>
@@ -13,5 +31,4 @@
       <%= t('defaults.not_found') %>
     </div>
   <% end %>
-</div>
 </div>

--- a/app/views/shared/_drawer_menu.html.erb
+++ b/app/views/shared/_drawer_menu.html.erb
@@ -13,6 +13,15 @@
         </ul>
       </details>
     </li>
+
+    <li>
+      <details>
+        <summary><%= t('drawer.summary.family_mini_memory') %></summary>
+        <ul>
+          <li><%= link_to t('drawer.list.family_memory_index'), family_memories_path %></li>
+        </ul>
+      </details>
+    </li>
   <% end %>
 
   <li>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -21,21 +21,21 @@
         <span><%= t('footer.mini_memory') %></span>
       <% end %>
 
-      <%# 投稿ボタン %>
-      <%= link_to new_memory_path, class: "flex flex-col items-center justify-center text-xs #{active_if_memories_new}" do %>
+      <%# 家族用ボタン %>
+      <%= link_to family_memories_path, class: "flex flex-col items-center justify-center text-xs #{active_if('family_memories')}" do %>
         <span class="text-xl">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v6m3-3H9m12 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z" />
           </svg>
         </span>
-        <span><%= t('footer.new_memory') %></span>
+        <span><%= t('footer.family_memory') %></span>
       <% end %>
 
-      <%# 掲示板ボタン %>
+      <%# 公開ボタン（dashboard の speech bubble に統一） %>
       <%= link_to public_memories_path, class: "flex flex-col items-center justify-center text-xs #{active_if("public_memories")}" do %>
         <span class="text-xl">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z" />
+          <svg xmlns="http://www.w3.org/2000/svg" class="size-6 fill-current" viewBox="0 -960 960 960">
+            <path d="M880-80 720-240H320q-33 0-56.5-23.5T240-320v-40h440q33 0 56.5-23.5T760-440v-280h40q33 0 56.5 23.5T880-640v560ZM160-473l47-47h393v-280H160v327ZM80-280v-520q0-33 23.5-56.5T160-880h440q33 0 56.5 23.5T680-800v280q0 33-23.5 56.5T600-440H240L80-280Zm80-240v-280 280Z"/>
           </svg>
         </span>
         <span><%= t('footer.board') %></span>

--- a/app/views/shared/_new_memory_fab.html.erb
+++ b/app/views/shared/_new_memory_fab.html.erb
@@ -1,0 +1,9 @@
+<% if user_signed_in? && show_new_memory_fab? %>
+  <%= link_to new_memory_path,
+        class: "fixed bottom-20 right-4 md:bottom-24 md:right-8 z-40 btn btn-primary btn-circle btn-lg shadow-lg",
+        aria: { label: t('family_memories.index.new_memory_fab_label') } do %>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="size-7">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+    </svg>
+  <% end %>
+<% end %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -21,5 +21,5 @@ ja:
     memory:
       visibility:
         private_only: 非公開
-        # unlisted: 家族グループメンバーのみ閲覧可能
+        unlisted: 家族グループメンバーのみ閲覧可能
         published: 掲示板にて誰でも閲覧可能

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,4 +1,14 @@
 ja:
+  family_memories:
+    index:
+      title: 家族のミニメモリ
+      subtitle: 家族メンバーが共有したミニメモリーを一覧で見られます
+      empty_no_group_title: 家族グループに所属していません
+      empty_no_group_subtitle: 家族グループに参加すると、メンバーが共有したミニメモリーを見られます
+      go_to_mypage: マイページへ
+      empty_no_memories: 家族メンバーのミニメモリーはまだありません
+      posted_by: "%{name}さんの投稿"
+      new_memory_fab_label: 新規投稿
   defaults:
     unknown_user: 不明なユーザー
     delete_confirm: 削除しますか？
@@ -53,6 +63,9 @@ ja:
         title: ログイン
         stay_logged_in: ログイン状態を保持する
   memories:
+    index:
+      title: わたしのミニメモリ
+      subtitle: あなたが投稿したミニメモリーの一覧です
     new:
       title: ミニメモリ新規投稿
       subtitle: 大切なモノをここに残しましょう
@@ -62,6 +75,9 @@ ja:
     show:
       return_to_list: 一覧に戻る
   public_memories:
+    index:
+      title: 掲示板
+      subtitle: 公開されたみんなのミニメモリーを見られます
     show:
       return_to_list: 一覧に戻る
   mypage:
@@ -119,11 +135,13 @@ ja:
     home: ホーム
     mini_memory: ミニメモリ
     new_memory: 新規投稿
+    family_memory: 家族のミニメモリ
     board: 掲示板
     enjoy: 楽しむ
   drawer:
     summary:
       mini_memory: 私のミニメモリ
+      family_mini_memory: 家族のミニメモリ
       everyone_mini_memory: みんなのミニメモリ
       account: アカウント
       others: その他
@@ -131,6 +149,7 @@ ja:
       create_memory: 新規投稿
       memory_index: ミニメモリ一覧
       enjoy: 楽しむ
+      family_memory_index: 家族のミニメモリ一覧
       board: 掲示板
       mypage: マイページ
       logout: ログアウト

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,10 @@ Rails.application.routes.draw do
   # 掲示板 - uuidをURLパラメータとして使用するため、param: :uuidを指定
   resources :public_memories, param: :uuid, only: %i[index show]
 
+  # 家族のミニメモリ - 家族メンバー横断のフィード（unlisted + published）。
+  # 詳細表示は既存の memories#show（MemoryPolicy#show? が家族メンバー閲覧を許可）に集約する。
+  resources :family_memories, only: %i[index]
+
   # 家族グループ - uuidをURLパラメータとして使用するため、param: :uuidを指定
   resources :family_groups, param: :uuid, only: %i[new create update show destroy] do
     # メンバーシップ操作（役割変更・脱退）。member 中間テーブルのため id は数値 ID。


### PR DESCRIPTION
 ## 概要                                                                                                                                                                                                                                             
  - 家族グループメンバー間で互いの投稿を閲覧できる **家族のミニメモリ一覧ページ**（家族フィード）を追加                                                                                                                                               
  - `Memory#visibility` の `unlisted` を **有効化**し、家族グループメンバーのみ閲覧可能な公開範囲として運用開始                                                                                                                                       
  - 新規投稿導線を **FAB（フローティングアクションボタン）化**し、フッター中央を「家族のミニメモリ」に置換                                                                                                                                            
  - 一覧系ページ（自分のミニメモリ / 家族のミニメモリ / 掲示板）の **ページヘッダーと背景テーマを統一**、アイコン体系をフッター基準に統一                                                                                                             
                                                                                                                                                                                                                                                      
  ## 関連 PR                                                                                                                                                                                                                                          
  - #225 家族のミニメモリ一覧ページとナビゲーション・UI 統一                                                                                                                                                                                          
  - #223 Memory#visibility の unlisted を有効化                                                                                                                                                                                                       
                                                                                                                                                                                                                                                      
  ## 主な変更点                                                                                                                                                                                                                                       
                                                                 
  ### 認可（Pundit）                                                                                                                                                                                                                                  
  - `MemoryPolicy#show?` に `record.unlisted? && family_member_of_owner?` を追加（家族メンバーは unlisted 投稿も閲覧可）
  - `FamilyFeedMemoryPolicy::Scope` を新設（Scope 専用 Policy）。家族メンバーが投稿した `unlisted` + `published` を返す 
  - `FamilyMemoriesController#index` で `policy_scope(Memory, policy_scope_class: FamilyFeedMemoryPolicy::Scope)` を使用                                                                                                                              
                                                                                                                                                                                                                                                      
  ### モデル / DB                                                                                                                                                                                                                                     
  - `Memory#visibility` enum に `unlisted: 1` を追加（数値は予約済みのものを利用、新規番号採番なし）                                                                                                                                                  
                                                                                                                                                                                                                                                      
  ### ルーティング                                                                                                                                                                                                                                    
  - `resources :family_memories, only: %i[index]` を追加         
  - 詳細表示は既存の `memories#show` に集約（Policy で家族メンバー閲覧を許可）                                                                                                                                                                        
                                                                                                                                                                                                                                                      
  ### UI / ナビゲーション                                                                                                                                                                                                                             
  - フッター: 中央の「新規投稿」を「家族のミニメモリ」に置換                                                                                                                                                                                          
  - 新規投稿: 右下 FAB（`show_new_memory_fab?` ヘルパーで new/create/edit/update 画面では非表示）                                                                                                                                                     
  - ドロワーメニュー: 「家族のミニメモリ」セクションを「みんなのミニメモリ」の前に追加                                                                                                                                                                
  - ダッシュボード: 「家族のミニメモリ」リンクカードを追加、各カードのアイコンをフッター基準に統一                                                                                                                                                    
  - 一覧ページ: 自分のミニメモリ / 家族のミニメモリ / 掲示板にページヘッダー（タイトル + サブタイトル + アイコン）を追加し、テーマカラー（rose / violet / emerald）を適用                                                                             
                                                                                                                                                                                                                                                      
  ### i18n                                                                                                                                                                                                                                            
  - `family_memories.index.*`, `memories.index.*`, `public_memories.index.*`, `footer.family_memory`, `drawer.*` を追加                                                                                                                               
  - `defaults.unknown_user` キー追加                                                                                                                                                                               
                                                                                                                                                                                                                                                      
  ## 動作確認済み（develop 上）                                                                                                                                                                                                                       
  - [x] 家族グループメンバー作成時に互いの unlisted 投稿が一覧に出る                                                                                                                                                                                  
  - [x] 家族グループ未所属ユーザーが家族のミニメモリページで空状態（「家族グループに所属していません」）になる                                                                                                                                        
  - [x] 家族メンバーが他メンバーの unlisted 詳細ページにアクセスできる                                                                                                                                                                                
  - [x] 非家族メンバーが unlisted 詳細ページにアクセスすると 403                                                                                                                                                                                      
  - [x] FAB が new / edit 画面では非表示                                                                                                                                                                                                              
  - [x] フッター・ドロワー・ダッシュボード・各一覧ページのアイコンが統一されている  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 家族メンバーのメモリーフィード機能を追加しました
  * メモリーの可視性に「非公開」オプションを追加（家族グループメンバーのみが表示可能）
  * ダッシュボードとナビゲーションメニューに「家族のミニメモリ」セクションを追加

* **UIの改善**
  * メモリーインデックスページのヘッダーデザインを更新
  * 公開メモリーページのレイアウトを改善
  * フッターナビゲーションを更新し、家族メモリー機能へのアクセスを追加

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tantp-1111/mini_memory/pull/226)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->