### PR TITLE
Pundit 設計メモを修正

### DIFF
--- a/docs/pundit-design.md
+++ b/docs/pundit-design.md
@@ -15,7 +15,10 @@
 | 5 | #212 | InvitationsController に Pundit 適用 |
 | 6 | #213 | Dashboard / Api::MemoryGames で `policy_scope` 適用 |
 | 7 | #215 | `verify_authorized` 有効化 |
-| 8 | #218 | メンバーシップ管理（役割変更 / 自己脱退 / owner kick） |
+| 8 | #218 | メンバーシップ管理（役割変更 / 自己脱退） |
+| 9 | #220 | owner kick + 本ドキュメント追加 |
+| 10 | #223 | `Memory#visibility#unlisted` を有効化（家族メンバー閲覧可） |
+| 11 | #225 | 家族フィード（`FamilyFeedMemoryPolicy` + `FamilyMemoriesController`） |
 
 各 PR を develop に積み、揃った後 main に一斉リリース。
 
@@ -80,6 +83,7 @@ Memory には公開フィード（`PublicMemoriesController`）があるため�
 | `InvitationsController#show` | token 検証のみで Pundit を経由しない設計 |
 | `DashboardController` 全体 | `policy_scope` のみで `authorize` を呼ばない |
 | `Api::MemoryGamesController` 全体 | 同上 |
+| `FamilyMemoriesController` 全体 | `policy_scope` のみで `authorize` を呼ばない |
 | `MypagesController` 全体 | 自分自身のプロフィール表示のため認可不要 |
 | `MemoryGamesController` 全体 | ゲーム画面の表示のみで認可対象レコードが無い |
 | `StaticPagesController` 全体 | 未認証ランディング |
@@ -89,7 +93,7 @@ Devise 系コントローラは `ApplicationController` の `after_action :verif
 
 ### 4. 認可とビジネスルールの分離
 
-`UserFamilyGroup` モデルの「最後の owner 保護」は Policy ではなく **モデル層の validation / before_destroy** で実装している:
+`UserFamilyGroup` モデルの「最後の owner 保護」は Policy ではなく **モデル層の validation / before_destroy** で実装:
 
 ```ruby
 # app/models/user_family_group.rb
@@ -106,7 +110,7 @@ before_destroy :ensure_at_least_one_owner_remains_after_leave
 
 ### 5. ビューの Policy 一元化
 
-ビューでは `policy(record).action?` を直接呼ぶ。コントローラに `@is_owner` のような真偽値を入れるインスタンス変数を作っていない。
+ビューでは `policy(record).action?` を直接呼ぶ。コントローラに `@is_owner` のような真偽値を入れるインスタンス変数を作らない方針にした。
 
 実装根拠（`app/views/family_groups/show.html.erb`）:
 - 招待リンク発行カードの表示判定: `<% if policy(@family_group).update? %>`
@@ -119,7 +123,7 @@ before_destroy :ensure_at_least_one_owner_remains_after_leave
 
 ### 6. 並行制御（コントローラ層で `lock!`）
 
-`UserFamilyGroupsController#update` / `#destroy` は `transaction { @family_group.lock!; ... }` で family_group 行を pessimistic lock している:
+`UserFamilyGroupsController#update` / `#destroy` は `transaction { @family_group.lock!; ... }` で family_group 行を 排他ロック:
 
 ```ruby
 def update
@@ -135,7 +139,7 @@ def update
 end
 ```
 
-ロック対象が family_group 行である理由: 同一グループへのメンバー変更は **同じ family_group 行** を介して直列化される。各トランザクションが「異なる owner 行」を個別にロックしても両者は競合せず race condition は解決しないため、グループ単位でロックしている。
+ロック対象が family_group 行である理由: 同一グループへのメンバー変更は **同じ family_group 行** を介して直列化される。各トランザクションが「異なる owner 行」を個別にロックしても両者は競合しない。グループ単位でロック。
 
 なお model の validation / before_destroy 自体は `lock!` を呼ばない（純粋な存在判定のみ）。
 
@@ -155,6 +159,54 @@ def kick?    = group_owner? && !self_membership?   # 除名ボタン表示
 - self-leave 時 → `mypage_path`
 - owner kick 時 → `family_group_path`
 
+### 8. visibility ごとの閲覧範囲を `show?` に集約
+
+`Memory#visibility` は 3 値（`private_only` / `unlisted` / `published`）。閲覧可否は `MemoryPolicy#show?` 内の論理和で表現する:
+
+```ruby
+def show? = record.published? || owner? || (record.unlisted? && family_member_of_owner?)
+```
+
+判定経路を1メソッドに集約することで、詳細ページ（`MemoriesController#show`）が visibility に関わらず同じ `authorize @memory` で動く。家族フィードから unlisted 投稿を開いても、本人が `published` を開いても、未ログインユーザーが `published` を開いても、入口は同じ。
+
+`family_member_of_owner?` は「自分の所属グループと投稿者の所属グループに重複があるか」を 1 クエリで判定する:
+
+```ruby
+def family_member_of_owner?
+  return false if user.nil?
+  user.family_groups.where(id: record.user.family_groups.select(:id)).exists?
+end
+```
+
+「1 ユーザー 1 グループ」制約下では実質「同じ家族グループに属しているか」と等価。`pluck` で配列に展開せずサブクエリとして渡している（DB内でクエリが完結されるため）。
+
+### 9. Scope 専用 Policy（同一モデルで Scope を切り替える）
+
+家族フィード（`FamilyMemoriesController#index`）は「家族メンバーが投稿した `unlisted` + `published`」を返す。これは `MemoryPolicy::Scope` の「自分の投稿のみ」とは別軸の集合。両方を `MemoryPolicy::Scope` 内で分岐させると Scope が肥大化するため、**Scope 専用の Policy** として `FamilyFeedMemoryPolicy` を切り出した:
+
+```ruby
+class FamilyFeedMemoryPolicy < ApplicationPolicy
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope.none if user.nil?
+      family_user_ids = UserFamilyGroup
+                          .where(family_group_id: user.family_groups.select(:id))
+                          .select(:user_id)
+      scope.where(user_id: family_user_ids, visibility: [ :unlisted, :published ])
+    end
+  end
+end
+```
+
+action 述語（`show?` 等）は持たない。controller 側で Pundit の `policy_scope_class:` オプションを使い、`Memory` モデルに対して別 Scope を明示指定する:
+
+```ruby
+@memories = policy_scope(Memory, policy_scope_class: FamilyFeedMemoryPolicy::Scope)
+              .with_attached_image.includes(:user).order(created_at: :desc)
+```
+
+詳細ページは `MemoriesController#show` に集約する（`MemoryPolicy#show?` が家族メンバー閲覧を許可する）ため、`FamilyMemoriesController` は index のみで完結する。
+
 ---
 
 ## `verify_authorized`
@@ -167,14 +219,7 @@ after_action :verify_authorized, unless: :devise_controller?
 
 各アクションで `authorize` が呼ばれていない場合、Pundit が `Pundit::AuthorizationNotPerformedError` を発生させる。`Pundit::NotAuthorizedError`（実行時の認可拒否）とは別の例外で、認可呼び忘れの検出に使う。
 
-`verify_policy_scoped` は導入していない。
-
----
-
-## トレードオフ
-
-- **未認可メッセージの汎用化**: `config/locales/pundit.ja.yml` は `not_authorized: 操作する権限がありません` のみ。Pundit 導入前に `FamilyGroupsController#destroy` 内に書かれていた「家族グループの削除はオーナーのみ可能です」のようなアクション固有のメッセージは、認可拒否経路では出なくなった。
-- **早期ブロック**: 既所属ユーザーが `/family_groups/new` を開いた時点で `FamilyGroupPolicy#new?`（`= create?`）が `user.user_family_groups.empty?` を返さず `Pundit::NotAuthorizedError` で弾かれる。`/family_groups` への POST 時の `RecordNotUnique` rescue も残してあるが、UI フロー上はそこに到達しない。
+チェック漏れを防ぐための`verify_policy_scoped` は導入していない。
 
 ---
 
@@ -182,8 +227,9 @@ after_action :verify_authorized, unless: :devise_controller?
 
 ```
 app/policies/
-├── application_policy.rb       基底クラス（全述語デフォルト false / Scope#resolve は NoMethodError）
+├── application_policy.rb           基底クラス（全述語デフォルト false / Scope#resolve は NoMethodError）
 ├── memory_policy.rb
+├── family_feed_memory_policy.rb    Scope 専用（policy_scope_class で指定）
 ├── family_group_policy.rb
 ├── user_family_group_policy.rb
 └── invitation_policy.rb
@@ -192,13 +238,3 @@ app/controllers/application_controller.rb  # Pundit::Authorization include / ver
 config/locales/pundit.ja.yml                # 未認可メッセージ I18n
 ```
 
----
-
-## 今後の判断のためのデフォルト原則
-
-1. 新規モデル → **Policy + Scope を最初に書く**（コントローラ適用は後でも可）
-2. **「機微 vs 公開」を最初に判断** → 機微なら二段防衛
-3. **認可（誰が）かビジネスルール（整合性）か** を意識してレイヤを選ぶ
-4. **ビューでは `policy(...)` を直接呼ぶ**。コントローラに `@is_xxx` ivar を作らない
-5. **並行性が重要な操作** はコントローラ層で `transaction { lock!; ... }`
-6. **Pundit を通さない判断** をする時は `skip_after_action :verify_authorized` で意図を明示


### PR DESCRIPTION
  ## 概要                                                                                                                                                                                                                                             
  - `docs/pundit-design.md` を最新の Pundit 関連 PR（#223 / #225）の内容で更新                                                                                                                                                               
                                                                                                                                                                                                                                                      
  ## 主な変更点                                                                                                                                                                                                                                       
  - 段階導入の PR 表に#223 / #225 を追加                                                                                                                                                               
  - `skip_after_action :verify_authorized` 対象表に `FamilyMemoriesController` を追加                                                                                                                                                                 
  - 設計判断セクションに以下を追加                                                                                                                                                                                                                    
    - **8. visibility ごとの閲覧範囲を `show?` に集約** — `MemoryPolicy#show?` の三項分岐と `family_member_of_owner?` の実装
    - **9. Scope 専用 Policy** — `FamilyFeedMemoryPolicy` を Scope 専用として切り出し、`policy_scope_class:` で指定するパターン                                                                                                                       
  - ファイル構成図に `family_feed_memory_policy.rb` を追加                                                                                                                                                                                            
                                                                                                                                                                                                                                                      
  ## 変更ファイル一覧                                                                                                                                                                                                                                 
  | ファイル | 種別 | 変更理由 |                                                                                                                                                                                                                      
  |---------|------|---------|                                                                                    
  | docs/pundit-design.md | 更新 | #223 / #225 の設計判断を反映 |   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * 認可システムの設計ドキュメントを更新し、コントローラー例外処理、認可判定、可視性制御に関する仕様を明確にしました。
  * 今後の実装判断に向けたデフォルト原則セクションを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tantp-1111/mini_memory/pull/228)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->