### PR TITLE
掲示板詳細ページにリアクション機能を追加 

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -1,0 +1,38 @@
+class ReactionsController < ApplicationController
+  before_action :set_memory
+
+  # リアクションを追加
+  def create
+    authorize @memory, :react?
+
+    reaction = @memory.reactions.build(
+      user: current_user,
+      reaction_type: params[:reaction_type]
+    )
+
+    if reaction.save
+      redirect_to public_memory_path(@memory)
+    else
+      redirect_to public_memory_path(@memory), alert: reaction.errors.full_messages.join(", ")
+    end
+  end
+
+  # リアクションを削除
+  def destroy
+    reaction = @memory.reactions.find_by!(
+      user: current_user,
+      reaction_type: params[:reaction_type]
+    )
+    authorize reaction
+
+    reaction.destroy!
+    redirect_to public_memory_path(@memory)
+  end
+
+  private
+
+  # ネスト元 public_memories が param: :uuid のため、params[:public_memory_uuid] で受け取る。
+  def set_memory
+    @memory = Memory.find_by!(uuid: params[:public_memory_uuid])
+  end
+end

--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -1,5 +1,6 @@
 class ReactionsController < ApplicationController
   before_action :set_memory
+  before_action :validate_reaction_type!, only: %i[create destroy]
 
   # リアクションを追加
   def create
@@ -15,6 +16,8 @@ class ReactionsController < ApplicationController
     else
       redirect_to public_memory_path(@memory), alert: reaction.errors.full_messages.join(", ")
     end
+  rescue ActiveRecord::RecordNotUnique
+    redirect_to public_memory_path(@memory), alert: "すでにそのリアクションは存在します"
   end
 
   # リアクションを削除
@@ -34,5 +37,10 @@ class ReactionsController < ApplicationController
   # ネスト元 public_memories が param: :uuid のため、params[:public_memory_uuid] で受け取る。
   def set_memory
     @memory = Memory.find_by!(uuid: params[:public_memory_uuid])
+  end
+
+  def validate_reaction_type!
+    return if Reaction.reaction_types.key?(params[:reaction_type])
+    redirect_to public_memory_path(`@memory`), alert: "不正なリアクション種別です"
   end
 end

--- a/app/helpers/reactions_helper.rb
+++ b/app/helpers/reactions_helper.rb
@@ -1,0 +1,27 @@
+module ReactionsHelper
+  REACTION_EMOJIS = {
+    "thumbs_up" => "👍",
+    "clap"      => "👏",
+    "heart"     => "❤️",
+    "laugh"     => "😂",
+    "tear_up"  => "🥺"
+  }.freeze
+
+  def reaction_emoji(reaction_type)
+    REACTION_EMOJIS[reaction_type]
+  end
+
+  # 押下済みなら primary、未押下なら outline のスタイルを返す
+  def reaction_button_class(reacted)
+    "btn btn-sm gap-1 #{reacted ? 'btn-primary' : 'btn-outline'}"
+  end
+
+  # ボタンが押せないときの理由（投稿者本人か未ログインかで出し分け）
+  def disabled_reaction_title(memory)
+    if memory.owned_by?(current_user)
+      "自分の投稿にはリアクションできません"
+    else
+      "ログインするとリアクションできます"
+    end
+  end
+end

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -8,6 +8,7 @@ class Memory < ApplicationRecord
   # アソシエーション
   belongs_to :user
   has_one_attached :image
+  has_many :reactions, dependent: :destroy
 
   # imageカスタムバリデーション
   validate :image_content_type
@@ -46,6 +47,29 @@ class Memory < ApplicationRecord
   # URLのパラメータとしてuuidを使用
   def to_param
     uuid
+  end
+
+  # user がこの memory の投稿者か（MemoryPolicy#owner? もこれを利用）
+  def owned_by?(user)
+    return false if user.nil?
+    user_id == user.id
+  end
+
+  # reaction関係
+  # リアクションの種類ごとの数を取得するメソッド
+  def reaction_count(reaction_type)
+    reactions.where(reaction_type: reaction_type).count
+  end
+
+  # 特定のユーザーがそのリアクションを押しているか確認
+  def reacted_by?(user, reaction_type)
+    reactions.exists?(user: user, reaction_type: reaction_type)
+  end
+
+  # user がこの memory にリアクション可能か（ログイン中 & 自分の投稿ではない）
+  def reactable_by?(user)
+    return false if user.nil?
+    !owned_by?(user)
   end
 
   private

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -1,0 +1,26 @@
+class Reaction < ApplicationRecord
+  belongs_to :user
+  belongs_to :memory
+
+  enum reaction_type: {
+    thumbs_up: 0,
+    clap: 1,
+    heart: 2,
+    laugh: 3,
+    tear_up: 4
+  }
+
+  # 同じユーザーが同じ掲示板に同じリアクションを重複して押せないようにする
+  validates :user_id, uniqueness: { scope: [ :memory_id, :reaction_type ] }
+
+  # 自分の投稿にはリアクションできないバリデーション
+  validate :cannot_react_to_own_memory
+
+  private
+
+  def cannot_react_to_own_memory
+    if memory.user_id == user_id
+      errors.add(:base, "自分の投稿にはリアクションできません")
+    end
+  end
+end

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -19,6 +19,7 @@ class Reaction < ApplicationRecord
   private
 
   def cannot_react_to_own_memory
+    return if memory.nil? || user_id.nil?
     if memory.user_id == user_id
       errors.add(:base, "自分の投稿にはリアクションできません")
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,7 @@ class User < ApplicationRecord
   has_many :memories, dependent: :destroy
   has_many :user_family_groups, dependent: :destroy
   has_many :family_groups, through: :user_family_groups
+  has_many :reactions, dependent: :destroy
 
   # バリデーション
   validates :name, presence: true

--- a/app/policies/memory_policy.rb
+++ b/app/policies/memory_policy.rb
@@ -10,7 +10,7 @@ class MemoryPolicy < ApplicationPolicy
   def update?  = owner?
   def destroy? = owner?
   # 公開投稿に対してリアクション可能か。判定ロジックは Memory#reactable_by? に集約。
-  def react?   = record.reactable_by?(user)
+  def react?   = record.published? && record.reactable_by?(user)
 
   class Scope < ApplicationPolicy::Scope
     def resolve

--- a/app/policies/memory_policy.rb
+++ b/app/policies/memory_policy.rb
@@ -9,6 +9,8 @@ class MemoryPolicy < ApplicationPolicy
   def create?  = user.present?
   def update?  = owner?
   def destroy? = owner?
+  # 公開投稿に対してリアクション可能か。判定ロジックは Memory#reactable_by? に集約。
+  def react?   = record.reactable_by?(user)
 
   class Scope < ApplicationPolicy::Scope
     def resolve
@@ -20,8 +22,7 @@ class MemoryPolicy < ApplicationPolicy
   private
 
   def owner?
-    return false if user.nil?
-    record.user_id == user.id
+    record.owned_by?(user)
   end
 
   # current_user の所属家族グループと record.user の所属家族グループに重複があるか。

--- a/app/policies/reaction_policy.rb
+++ b/app/policies/reaction_policy.rb
@@ -1,0 +1,9 @@
+# Reaction の認可ルール。
+# 作成可否は MemoryPolicy#react? が担当（リソースの主は Memory のため）。
+# 当ポリシーは「個別のリアクションを削除できるか」を判定する。
+class ReactionPolicy < ApplicationPolicy
+  def destroy?
+    return false if user.nil?
+    record.user_id == user.id
+  end
+end

--- a/app/views/memories/show.html.erb
+++ b/app/views/memories/show.html.erb
@@ -81,7 +81,7 @@
 
       <%# ボタン群 %>
       <div class="flex flex-col gap-3 pt-2">
-        <% if current_user == @memory.user %>
+        <% if policy(@memory).edit? %>
           <div class="flex gap-3">
             <%= link_to edit_memory_path(@memory),
                 id: "button-edit-memory-#{@memory.id}",

--- a/app/views/public_memories/show.html.erb
+++ b/app/views/public_memories/show.html.erb
@@ -67,9 +67,17 @@
         </div>
       </div>
 
+      <%# リアクション %>
+      <div>
+        <p class="text-xs font-bold tracking-widest text-base-content/40 mb-3">
+          リアクション
+        </p>
+        <%= render "reactions/reactions", memory: @memory %>
+      </div>
+
       <%# ボタン群 %>
       <div class="flex flex-col gap-3 pt-2">
-        <% if current_user == @memory.user %>
+        <% if policy(@memory).edit? %>
           <div class="flex gap-3">
             <%= link_to edit_memory_path(@memory),
                 id: "button-edit-memory-#{@memory.id}",

--- a/app/views/reactions/_reactions.html.erb
+++ b/app/views/reactions/_reactions.html.erb
@@ -1,0 +1,33 @@
+<%# 掲示板詳細でのリアクションボタン列。memory は必須ローカル変数。 %>
+<div class="flex items-center gap-2 flex-wrap">
+  <% Reaction.reaction_types.keys.each do |type| %>
+    <% if memory.reactable_by?(current_user) %>
+      <% if memory.reacted_by?(current_user, type) %>
+        <%= button_to public_memory_reaction_path(memory, type),
+                      method: :delete,
+                      class: reaction_button_class(true),
+                      form: { class: "inline-block" } do %>
+          <span><%= reaction_emoji(type) %></span>
+          <span class="text-xs"><%= memory.reaction_count(type) %></span>
+        <% end %>
+      <% else %>
+        <%= button_to public_memory_reactions_path(memory),
+                      method: :post,
+                      params: { reaction_type: type },
+                      class: reaction_button_class(false),
+                      form: { class: "inline-block" } do %>
+          <span><%= reaction_emoji(type) %></span>
+          <span class="text-xs"><%= memory.reaction_count(type) %></span>
+        <% end %>
+      <% end %>
+    <% else %>
+      <button type="button"
+              class="<%= reaction_button_class(memory.reacted_by?(current_user, type)) %>"
+              disabled
+              title="<%= disabled_reaction_title(memory) %>">
+        <span><%= reaction_emoji(type) %></span>
+        <span class="text-xs"><%= memory.reaction_count(type) %></span>
+      </button>
+    <% end %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,12 @@ Rails.application.routes.draw do
   resources :memories, param: :uuid, only: %i[index new create show edit update destroy]
 
   # 掲示板 - uuidをURLパラメータとして使用するため、param: :uuidを指定
-  resources :public_memories, param: :uuid, only: %i[index show]
+  resources :public_memories, param: :uuid, only: %i[index show] do
+    # リアクション - 識別子に reaction_type(enum キー) を使う。
+    # POST   /public_memories/:public_memory_uuid/reactions                 → create
+    # DELETE /public_memories/:public_memory_uuid/reactions/:reaction_type  → destroy
+    resources :reactions, only: %i[create destroy], param: :reaction_type
+  end
 
   # 家族のミニメモリ - 家族メンバー横断のフィード（unlisted + published）。
   # 詳細表示は既存の memories#show（MemoryPolicy#show? が家族メンバー閲覧を許可）に集約する。

--- a/db/migrate/20260516160637_create_reactions.rb
+++ b/db/migrate/20260516160637_create_reactions.rb
@@ -3,7 +3,7 @@ class CreateReactions < ActiveRecord::Migration[7.2]
     create_table :reactions do |t|
       t.references :user, null: false, foreign_key: true
       t.references :memory, null: false, foreign_key: true
-      t.integer :reaction_type
+      t.integer :reaction_type, null: false
 
       t.timestamps
     end

--- a/db/migrate/20260516160637_create_reactions.rb
+++ b/db/migrate/20260516160637_create_reactions.rb
@@ -1,0 +1,13 @@
+class CreateReactions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :reactions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :memory, null: false, foreign_key: true
+      t.integer :reaction_type
+
+      t.timestamps
+    end
+
+    add_index :reactions, [ :user_id, :memory_id, :reaction_type ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_20_145827) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_16_160637) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -74,6 +74,17 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_20_145827) do
     t.index ["uuid"], name: "index_memories_on_uuid", unique: true
   end
 
+  create_table "reactions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "memory_id", null: false
+    t.integer "reaction_type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["memory_id"], name: "index_reactions_on_memory_id"
+    t.index ["user_id", "memory_id", "reaction_type"], name: "index_reactions_on_user_id_and_memory_id_and_reaction_type", unique: true
+    t.index ["user_id"], name: "index_reactions_on_user_id"
+  end
+
   create_table "user_family_groups", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "family_group_id", null: false
@@ -105,6 +116,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_20_145827) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "invitations", "family_groups"
   add_foreign_key "memories", "users"
+  add_foreign_key "reactions", "memories"
+  add_foreign_key "reactions", "users"
   add_foreign_key "user_family_groups", "family_groups"
   add_foreign_key "user_family_groups", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,7 +77,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_16_160637) do
   create_table "reactions", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "memory_id", null: false
-    t.integer "reaction_type"
+    t.integer "reaction_type", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["memory_id"], name: "index_reactions_on_memory_id"

--- a/test/controllers/reactions_controller_test.rb
+++ b/test/controllers/reactions_controller_test.rb
@@ -1,0 +1,4 @@
+require "test_helper"
+
+class ReactionsControllerTest < ActionDispatch::IntegrationTest
+end

--- a/test/fixtures/reactions.yml
+++ b/test/fixtures/reactions.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  memory: one
+  reaction_type: 1
+
+two:
+  user: two
+  memory: two
+  reaction_type: 2

--- a/test/models/reaction_test.rb
+++ b/test/models/reaction_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ReactionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要                                                    
  - 掲示板の詳細ページ（`public_memories#show`）に絵文字リアクション機能を追加
  - 5 種類のリアクション（👍 / 👏 / ❤️  / 😂 / 🥺）をユーザーが他人の投稿に対して 1 種類ずつ押下・取り消しできる                                                                                                                               
  - 認可は Pundit に統一（リアクション付与 = `MemoryPolicy#react?` / 削除 = `ReactionPolicy#destroy?`）                                                                                                                                       
                                                                                                                                                                                                                                              
  ## 主な変更点                                                                                                                                                                                                                               
                                                                                                                                                                                                                                              
  ### DB / モデル                                                                                                                                                                                                                             
  - `reactions` テーブル新設（user_id / memory_id / reaction_type / timestamps）
  - `(user_id, memory_id, reaction_type)` の複合 **unique index** で重複押下を DB レベルで防御                                                                                                                                                
  - `Reaction` モデル                                                                                                                                                                                                                         
    - `enum reaction_type: { thumbs_up:0, clap:1, heart:2, laugh:3, tear_up:4 }`
    - uniqueness validation + 自己投稿禁止の custom validation で **二重防御**                                                                                                                                                                
  - `Memory` に判定用メソッドを追加（view と policy の両方から参照）                                                                                                                                                                          
    - `owned_by?(user)` / `reactable_by?(user)` / `reacted_by?(user, type)` / `reaction_count(type)`                                                                                                                                          
  - `User` / `Memory` に `has_many :reactions, dependent: :destroy`                                                                                                                                                                           
                                                                                                                                                                                                                                              
  ### 認可（Pundit）                                                                                                                                                                                                                          
  - `MemoryPolicy#owner?` も `Memory#owned_by?` に統一                                                              
  - `ReactionPolicy#destroy?` は押下した本人のみ許可                                                                                                                                                                                          
                                                                                                                                                                                                                                              
  ### ルーティング                                                                                                                                                                                                                            
  - `public_memories` 配下に nested で `resources :reactions, only: %i[create destroy], param: :reaction_type`                                                                                                                                
    - `POST   /public_memories/:public_memory_uuid/reactions`                                                                                                                                                                                 
    - `DELETE /public_memories/:public_memory_uuid/reactions/:reaction_type`                                                                                                                                                                  
                                                                            
  ### コントローラ                                                                                                                                                                                                                 
  - `ReactionsController#create` は `authorize @memory, :react?` 経由                                               
  - `ReactionsController#destroy` は `authorize @reaction` 経由
 
                                                                            
  ### ビュー                                                                                                                                                                                
  - 投稿者本人 / 未ログイン時は disabled ボタンを表示                                                                                                                                                       
  - 編集ボタンの可視判定を `current_user == @memory.user` から `policy(@memory).edit?` に置換し、`memories/show` と `public_memories/show` の両方を Pundit に一本化                                                                           

  ## 変更ファイル一覧                                                                                                                                                                                                                         
                                                                                                                                                                                                                                              
  | ファイル | 種別 | 変更理由 |                                                                                                                                                                                                              
  |---------|------|---------|                                                                                      
  | db/migrate/20260516160637_create_reactions.rb | 新規 | reactions テーブルと unique index |
  | db/schema.rb | 更新 | migration の反映 |                                                                                                                                                                                                  
  | app/models/reaction.rb | 新規 | enum / validation / 自己投稿禁止 |                                                                                                                                                                        
  | app/models/memory.rb | 更新 | has_many + 判定メソッド 4 つ |                                                                                                                                                                              
  | app/models/user.rb | 更新 | has_many :reactions |                                                                                                                                                                                         
  | app/policies/memory_policy.rb | 更新 | `react?` 追加、`owner?` を Memory に委譲 |                                                                                                                                                         
  | app/policies/reaction_policy.rb | 新規 | destroy? のみ |                                                                                                                                                                                  
  | config/routes.rb | 更新 | nested reactions（param: :reaction_type） |                                                                                                                                                                     
  | app/controllers/reactions_controller.rb | 新規 | create / destroy |                                             
  | app/helpers/reactions_helper.rb | 新規 | 絵文字マップ / ボタンスタイル / disabled 理由 |                                                                                                                                                  
  | app/views/reactions/_reactions.html.erb | 新規 | 5 種類のボタン列パーシャル |                                                                                                                                                             
  | app/views/public_memories/show.html.erb | 更新 | リアクション UI 挿入 / 編集判定 policy 化 |                                                                                                                                              
  | app/views/memories/show.html.erb | 更新 | 編集判定 policy 化 | 

## 実装のポイント                                                                                                                                                                                                                           
                                                                                                                    
  - **判定ロジックを Memory に集約**: `reactable_by?` / `owned_by?` を Memory に置くことで、Policy / View / Helper のいずれからも同じ式を参照できる                                                                                           
  - **二重防御**: アプリ層の uniqueness validation + DB の複合 unique index。同時クリック等の race condition でも DB レベルで `ActiveRecord::RecordNotUnique` を返す                                                                          
  - **URL パラメータに enum キーを採用**: `param: :reaction_type` で `params[:reaction_type]` から直接 enum 値を取得できる                                          
  - **未ログイン / 投稿者本人にも UI を出す**: disabled ボタンとして表示し、title 属性で理由を提示（カウントは見える）                                                                                                                        
                                                                                                                                                                                                                                              
  ## 動作確認済み                                                                                                                                                                                                                             
  - [x] 他人の published 投稿に 5 種類すべてリアクションを押下できる                                                                                                                                                                          
  - [x] 同じ種類を再度押すと取り消される                                                                                                                                                                                                      
  - [x] 自分の投稿には disabled で押せない                                                                                                                                                                                                    
  - [x] 未ログイン時も disabled で押せない                                                                                                                                                                                                    
                                                                                                                                                                      


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 投稿にリアクション機能を追加しました。5種類の絵文字（👍👏❤️😂🥺）でコンテンツへの反応を表現できます。
  * リアクション表示セクションをメモリー詳細ページに追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tantp-1111/mini_memory/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->