### PR TITLE
掲示板のリアクション操作を Turbo Stream で ajax化 + i18n 化

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -12,12 +12,21 @@ class ReactionsController < ApplicationController
     )
 
     if reaction.save
-      redirect_to public_memory_path(@memory)
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to public_memory_path(@memory) }
+      end
     else
-      redirect_to public_memory_path(@memory), alert: reaction.errors.full_messages.join(", ")
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to public_memory_path(@memory), alert: reaction.errors.full_messages.join(", ") }
+      end
     end
   rescue ActiveRecord::RecordNotUnique
-    redirect_to public_memory_path(@memory), alert: "すでにそのリアクションは存在します"
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to public_memory_path(@memory), alert: t("reactions.alert.already_exists") }
+    end
   end
 
   # リアクションを削除
@@ -29,7 +38,10 @@ class ReactionsController < ApplicationController
     authorize reaction
 
     reaction.destroy!
-    redirect_to public_memory_path(@memory)
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to public_memory_path(@memory) }
+    end
   end
 
   private
@@ -41,6 +53,6 @@ class ReactionsController < ApplicationController
 
   def validate_reaction_type!
     return if Reaction.reaction_types.key?(params[:reaction_type])
-    redirect_to public_memory_path(`@memory`), alert: "不正なリアクション種別です"
+    redirect_to public_memory_path(@memory), alert: t("reactions.alert.invalid_type")
   end
 end

--- a/app/helpers/reactions_helper.rb
+++ b/app/helpers/reactions_helper.rb
@@ -19,9 +19,9 @@ module ReactionsHelper
   # ボタンが押せないときの理由（投稿者本人か未ログインかで出し分け）
   def disabled_reaction_title(memory)
     if memory.owned_by?(current_user)
-      "自分の投稿にはリアクションできません"
+      I18n.t("reactions.disabled_reason.own_post")
     else
-      "ログインするとリアクションできます"
+      I18n.t("reactions.disabled_reason.not_logged_in")
     end
   end
 end

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -20,8 +20,9 @@ class Reaction < ApplicationRecord
 
   def cannot_react_to_own_memory
     return if memory.nil? || user_id.nil?
-    if memory.user_id == user_id
-      errors.add(:base, "自分の投稿にはリアクションできません")
-    end
+    return unless memory.user_id == user_id
+
+    # i18n キー: activerecord.errors.models.reaction.attributes.base.own_post
+    errors.add(:base, :own_post)
   end
 end

--- a/app/views/public_memories/show.html.erb
+++ b/app/views/public_memories/show.html.erb
@@ -69,9 +69,6 @@
 
       <%# リアクション %>
       <div>
-        <p class="text-xs font-bold tracking-widest text-base-content/40 mb-3">
-          リアクション
-        </p>
         <%= render "reactions/reactions", memory: @memory %>
       </div>
 

--- a/app/views/reactions/_reactions.html.erb
+++ b/app/views/reactions/_reactions.html.erb
@@ -1,5 +1,5 @@
 <%# 掲示板詳細でのリアクションボタン列。memory は必須ローカル変数。 %>
-<div class="flex items-center gap-2 flex-wrap">
+<div id="reactions_<%= memory.id %>" class="flex items-center gap-2 flex-wrap">
   <% Reaction.reaction_types.keys.each do |type| %>
     <% if memory.reactable_by?(current_user) %>
       <% if memory.reacted_by?(current_user, type) %>

--- a/app/views/reactions/create.turbo_stream.erb
+++ b/app/views/reactions/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "reactions_#{@memory.id}" do %>
+  <%= render "reactions/reactions", memory: @memory %>
+<% end %>

--- a/app/views/reactions/destroy.turbo_stream.erb
+++ b/app/views/reactions/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "reactions_#{@memory.id}" do %>
+  <%= render "reactions/reactions", memory: @memory %>
+<% end %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       user: ユーザー
       memory: 思い出
+      reaction: リアクション
     attributes:
       user:
         email: メールアドレス
@@ -17,6 +18,14 @@ ja:
         image: 画像
       user_family_group:
         role: 役割
+      reaction:
+        reaction_type: リアクションの種類
+    errors:
+      models:
+        reaction:
+          attributes:
+            base:
+              own_post: 自分の投稿にはリアクションできません
   enums:
     memory:
       visibility:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -80,6 +80,13 @@ ja:
       subtitle: 公開されたみんなのミニメモリーを見られます
     show:
       return_to_list: 一覧に戻る
+  reactions:
+    alert:
+      already_exists: すでにそのリアクションは存在します
+      invalid_type: 不正なリアクション種別です
+    disabled_reason:
+      own_post: 自分の投稿にはリアクションできません
+      not_logged_in: ログインするとリアクションできます
   mypage:
     account_title: プロフィール
     account_subtitle: アカウント情報を確認できます


### PR DESCRIPTION
## 概要                                                    
  - 掲示板のリアクション押下・取り消しをページ全体再読込なしの **Turbo Stream** で部分更新化                                                                                                                                                 
  - 同時に日本語ハードコードを **i18n 化**（locales / model / helper / controller alert）                                                                                                                                                    

 ## 主な変更点                                                                                                                                                                                                                              
                                                                                                                                                                                                                                             
  ### Turbo Stream 部分更新                                                                                                                                                                                                                  
  - `ReactionsController#create` / `#destroy` を `respond_to do |format|` で turbo_stream / html に分岐
  - `format.turbo_stream` は暗黙ルックアップに任せ、`create.turbo_stream.erb` / `destroy.turbo_stream.erb` を自動 render（明示の `render` を書かない）                                                                                       
  - `app/views/reactions/_reactions.html.erb` の最外殻に `id="reactions_<%= memory.id %>"` を付与し、`turbo_stream.replace` の差し替え対象を明示

## 変更ファイル一覧                                                                                                                                                                                                                        
                                                                                                                                                                                                                                             
  | ファイル | 種別 | 変更理由 |                                                                                                                                                                                                             
  |---|---|---|                                                                                                                                                                                                                              
  | app/controllers/reactions_controller.rb | 更新 | respond_to 分岐 + alert i18n + typo 修正 |                     
  | app/views/reactions/_reactions.html.erb | 更新 | Turbo Stream の差し替え target 用に id 付与 |
  | app/views/reactions/create.turbo_stream.erb | 新規 | 押下成功時の部分更新テンプレート |                                                                                                                                                  
  | app/views/reactions/destroy.turbo_stream.erb | 新規 | 取消し成功時の部分更新テンプレート |                                                                                                                                               
  | app/models/reaction.rb | 更新 | エラーを `:own_post` シンボル指定に |                                                                                                                                                                    
  | app/helpers/reactions_helper.rb | 更新 | tooltip 文言を `I18n.t` に置換 |                                                                                                                                                                
  | config/locales/activerecord/ja.yml | 更新 | reaction model / attributes / errors キー追加 |                                                                                                                                              
  | config/locales/views/ja.yml | 更新 | reactions.alert / reactions.disabled_reason キー追加 |                                                                                                                                              
  | app/views/public_memories/show.html.erb | 更新 | 冗長な「リアクション」セクション見出しを削除 |                                                                                                                                          
                                                                                                                                                                                                                                             
  ## 実装のポイント                                                                                                                                                                                                                          
                                                                                                                                                                                                                                             
  - **Rails の暗黙的テンプレートルックアップに任せる**: `format.turbo_stream` の 1 行だけで `<action名>.turbo_stream.erb` が自動 render される。インラインで `render turbo_stream: turbo_stream.replace(...)` を書くと controller
  とテンプレートで同じ内容を二重に書くことになるため避ける                                                                                                                                                                                   
  - **`format.html` を必ず残す**: JS 無効 / curl / `Accept: text/html` のクライアントで `ActionController::UnknownFormat` を出さないため
  - **model error は `:own_post` シンボル指定**: `errors.add(:base, :own_post)` で `activerecord.errors.models.reaction.attributes.base.own_post` を Rails が自動ルックアップする標準的な書き方                                              
                                                                                                                                                                                                                                             
  ## 動作確認済み                                                                                                                                                                                                                            
  - [x] 他人の published 投稿にリアクションを押下するとカードだけが部分更新される                                                                                                                                                            
  - [x] 同じ種類を再度押すと取り消しも部分更新される                                                                                                                                                                                         
  - [x] 他のリアクションボタンの状態は維持される                                                                                                                                                                                             
  - [x] スクロール位置が維持される                                                                                                                                                                                                           
  - [x] 全 i18n キーが `bin/rails runner I18n.t(...)` で正しく解決されることを確認                                                                                                                                                           

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * リアクション機能がリアルタイム更新に対応しました

* **改善**
  * リアクション操作時のエラーメッセージを充実させました（重複、無効な種別、自投稿への反応など）
  * エラーメッセージの表示が日本語で統一されました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tantp-1111/mini_memory/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->