### PR TITLE
[Release] 掲示板リアクション機能実装

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -12,12 +12,21 @@ class ReactionsController < ApplicationController
     )
 
     if reaction.save
-      redirect_to public_memory_path(@memory)
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to public_memory_path(@memory) }
+      end
     else
-      redirect_to public_memory_path(@memory), alert: reaction.errors.full_messages.join(", ")
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to public_memory_path(@memory), alert: reaction.errors.full_messages.join(", ") }
+      end
     end
   rescue ActiveRecord::RecordNotUnique
-    redirect_to public_memory_path(@memory), alert: "すでにそのリアクションは存在します"
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to public_memory_path(@memory), alert: t("reactions.alert.already_exists") }
+    end
   end
 
   # リアクションを削除
@@ -29,7 +38,10 @@ class ReactionsController < ApplicationController
     authorize reaction
 
     reaction.destroy!
-    redirect_to public_memory_path(@memory)
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to public_memory_path(@memory) }
+    end
   end
 
   private
@@ -41,6 +53,6 @@ class ReactionsController < ApplicationController
 
   def validate_reaction_type!
     return if Reaction.reaction_types.key?(params[:reaction_type])
-    redirect_to public_memory_path(`@memory`), alert: "不正なリアクション種別です"
+    redirect_to public_memory_path(@memory), alert: t("reactions.alert.invalid_type")
   end
 end

--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -1,0 +1,38 @@
+class ReactionsController < ApplicationController
+  before_action :set_memory
+
+  # リアクションを追加
+  def create
+    authorize @memory, :react?
+
+    reaction = @memory.reactions.build(
+      user: current_user,
+      reaction_type: params[:reaction_type]
+    )
+
+    if reaction.save
+      redirect_to public_memory_path(@memory)
+    else
+      redirect_to public_memory_path(@memory), alert: reaction.errors.full_messages.join(", ")
+    end
+  end
+
+  # リアクションを削除
+  def destroy
+    reaction = @memory.reactions.find_by!(
+      user: current_user,
+      reaction_type: params[:reaction_type]
+    )
+    authorize reaction
+
+    reaction.destroy!
+    redirect_to public_memory_path(@memory)
+  end
+
+  private
+
+  # ネスト元 public_memories が param: :uuid のため、params[:public_memory_uuid] で受け取る。
+  def set_memory
+    @memory = Memory.find_by!(uuid: params[:public_memory_uuid])
+  end
+end

--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -1,5 +1,6 @@
 class ReactionsController < ApplicationController
   before_action :set_memory
+  before_action :validate_reaction_type!, only: %i[create destroy]
 
   # リアクションを追加
   def create
@@ -15,6 +16,8 @@ class ReactionsController < ApplicationController
     else
       redirect_to public_memory_path(@memory), alert: reaction.errors.full_messages.join(", ")
     end
+  rescue ActiveRecord::RecordNotUnique
+    redirect_to public_memory_path(@memory), alert: "すでにそのリアクションは存在します"
   end
 
   # リアクションを削除
@@ -34,5 +37,10 @@ class ReactionsController < ApplicationController
   # ネスト元 public_memories が param: :uuid のため、params[:public_memory_uuid] で受け取る。
   def set_memory
     @memory = Memory.find_by!(uuid: params[:public_memory_uuid])
+  end
+
+  def validate_reaction_type!
+    return if Reaction.reaction_types.key?(params[:reaction_type])
+    redirect_to public_memory_path(`@memory`), alert: "不正なリアクション種別です"
   end
 end

--- a/app/helpers/reactions_helper.rb
+++ b/app/helpers/reactions_helper.rb
@@ -19,9 +19,9 @@ module ReactionsHelper
   # ボタンが押せないときの理由（投稿者本人か未ログインかで出し分け）
   def disabled_reaction_title(memory)
     if memory.owned_by?(current_user)
-      "自分の投稿にはリアクションできません"
+      I18n.t("reactions.disabled_reason.own_post")
     else
-      "ログインするとリアクションできます"
+      I18n.t("reactions.disabled_reason.not_logged_in")
     end
   end
 end

--- a/app/helpers/reactions_helper.rb
+++ b/app/helpers/reactions_helper.rb
@@ -1,0 +1,27 @@
+module ReactionsHelper
+  REACTION_EMOJIS = {
+    "thumbs_up" => "👍",
+    "clap"      => "👏",
+    "heart"     => "❤️",
+    "laugh"     => "😂",
+    "tear_up"  => "🥺"
+  }.freeze
+
+  def reaction_emoji(reaction_type)
+    REACTION_EMOJIS[reaction_type]
+  end
+
+  # 押下済みなら primary、未押下なら outline のスタイルを返す
+  def reaction_button_class(reacted)
+    "btn btn-sm gap-1 #{reacted ? 'btn-primary' : 'btn-outline'}"
+  end
+
+  # ボタンが押せないときの理由（投稿者本人か未ログインかで出し分け）
+  def disabled_reaction_title(memory)
+    if memory.owned_by?(current_user)
+      "自分の投稿にはリアクションできません"
+    else
+      "ログインするとリアクションできます"
+    end
+  end
+end

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -8,6 +8,7 @@ class Memory < ApplicationRecord
   # アソシエーション
   belongs_to :user
   has_one_attached :image
+  has_many :reactions, dependent: :destroy
 
   # imageカスタムバリデーション
   validate :image_content_type
@@ -46,6 +47,29 @@ class Memory < ApplicationRecord
   # URLのパラメータとしてuuidを使用
   def to_param
     uuid
+  end
+
+  # user がこの memory の投稿者か（MemoryPolicy#owner? もこれを利用）
+  def owned_by?(user)
+    return false if user.nil?
+    user_id == user.id
+  end
+
+  # reaction関係
+  # リアクションの種類ごとの数を取得するメソッド
+  def reaction_count(reaction_type)
+    reactions.where(reaction_type: reaction_type).count
+  end
+
+  # 特定のユーザーがそのリアクションを押しているか確認
+  def reacted_by?(user, reaction_type)
+    reactions.exists?(user: user, reaction_type: reaction_type)
+  end
+
+  # user がこの memory にリアクション可能か（ログイン中 & 自分の投稿ではない）
+  def reactable_by?(user)
+    return false if user.nil?
+    !owned_by?(user)
   end
 
   private

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -1,0 +1,26 @@
+class Reaction < ApplicationRecord
+  belongs_to :user
+  belongs_to :memory
+
+  enum reaction_type: {
+    thumbs_up: 0,
+    clap: 1,
+    heart: 2,
+    laugh: 3,
+    tear_up: 4
+  }
+
+  # 同じユーザーが同じ掲示板に同じリアクションを重複して押せないようにする
+  validates :user_id, uniqueness: { scope: [ :memory_id, :reaction_type ] }
+
+  # 自分の投稿にはリアクションできないバリデーション
+  validate :cannot_react_to_own_memory
+
+  private
+
+  def cannot_react_to_own_memory
+    if memory.user_id == user_id
+      errors.add(:base, "自分の投稿にはリアクションできません")
+    end
+  end
+end

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -20,8 +20,9 @@ class Reaction < ApplicationRecord
 
   def cannot_react_to_own_memory
     return if memory.nil? || user_id.nil?
-    if memory.user_id == user_id
-      errors.add(:base, "自分の投稿にはリアクションできません")
-    end
+    return unless memory.user_id == user_id
+
+    # i18n キー: activerecord.errors.models.reaction.attributes.base.own_post
+    errors.add(:base, :own_post)
   end
 end

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -19,6 +19,7 @@ class Reaction < ApplicationRecord
   private
 
   def cannot_react_to_own_memory
+    return if memory.nil? || user_id.nil?
     if memory.user_id == user_id
       errors.add(:base, "自分の投稿にはリアクションできません")
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,7 @@ class User < ApplicationRecord
   has_many :memories, dependent: :destroy
   has_many :user_family_groups, dependent: :destroy
   has_many :family_groups, through: :user_family_groups
+  has_many :reactions, dependent: :destroy
 
   # バリデーション
   validates :name, presence: true

--- a/app/policies/memory_policy.rb
+++ b/app/policies/memory_policy.rb
@@ -10,7 +10,7 @@ class MemoryPolicy < ApplicationPolicy
   def update?  = owner?
   def destroy? = owner?
   # 公開投稿に対してリアクション可能か。判定ロジックは Memory#reactable_by? に集約。
-  def react?   = record.reactable_by?(user)
+  def react?   = record.published? && record.reactable_by?(user)
 
   class Scope < ApplicationPolicy::Scope
     def resolve

--- a/app/policies/memory_policy.rb
+++ b/app/policies/memory_policy.rb
@@ -9,6 +9,8 @@ class MemoryPolicy < ApplicationPolicy
   def create?  = user.present?
   def update?  = owner?
   def destroy? = owner?
+  # 公開投稿に対してリアクション可能か。判定ロジックは Memory#reactable_by? に集約。
+  def react?   = record.reactable_by?(user)
 
   class Scope < ApplicationPolicy::Scope
     def resolve
@@ -20,8 +22,7 @@ class MemoryPolicy < ApplicationPolicy
   private
 
   def owner?
-    return false if user.nil?
-    record.user_id == user.id
+    record.owned_by?(user)
   end
 
   # current_user の所属家族グループと record.user の所属家族グループに重複があるか。

--- a/app/policies/reaction_policy.rb
+++ b/app/policies/reaction_policy.rb
@@ -1,0 +1,9 @@
+# Reaction の認可ルール。
+# 作成可否は MemoryPolicy#react? が担当（リソースの主は Memory のため）。
+# 当ポリシーは「個別のリアクションを削除できるか」を判定する。
+class ReactionPolicy < ApplicationPolicy
+  def destroy?
+    return false if user.nil?
+    record.user_id == user.id
+  end
+end

--- a/app/views/memories/show.html.erb
+++ b/app/views/memories/show.html.erb
@@ -81,7 +81,7 @@
 
       <%# ボタン群 %>
       <div class="flex flex-col gap-3 pt-2">
-        <% if current_user == @memory.user %>
+        <% if policy(@memory).edit? %>
           <div class="flex gap-3">
             <%= link_to edit_memory_path(@memory),
                 id: "button-edit-memory-#{@memory.id}",

--- a/app/views/public_memories/show.html.erb
+++ b/app/views/public_memories/show.html.erb
@@ -69,9 +69,6 @@
 
       <%# リアクション %>
       <div>
-        <p class="text-xs font-bold tracking-widest text-base-content/40 mb-3">
-          リアクション
-        </p>
         <%= render "reactions/reactions", memory: @memory %>
       </div>
 

--- a/app/views/public_memories/show.html.erb
+++ b/app/views/public_memories/show.html.erb
@@ -67,9 +67,17 @@
         </div>
       </div>
 
+      <%# リアクション %>
+      <div>
+        <p class="text-xs font-bold tracking-widest text-base-content/40 mb-3">
+          リアクション
+        </p>
+        <%= render "reactions/reactions", memory: @memory %>
+      </div>
+
       <%# ボタン群 %>
       <div class="flex flex-col gap-3 pt-2">
-        <% if current_user == @memory.user %>
+        <% if policy(@memory).edit? %>
           <div class="flex gap-3">
             <%= link_to edit_memory_path(@memory),
                 id: "button-edit-memory-#{@memory.id}",

--- a/app/views/reactions/_reactions.html.erb
+++ b/app/views/reactions/_reactions.html.erb
@@ -1,5 +1,5 @@
 <%# 掲示板詳細でのリアクションボタン列。memory は必須ローカル変数。 %>
-<div class="flex items-center gap-2 flex-wrap">
+<div id="reactions_<%= memory.id %>" class="flex items-center gap-2 flex-wrap">
   <% Reaction.reaction_types.keys.each do |type| %>
     <% if memory.reactable_by?(current_user) %>
       <% if memory.reacted_by?(current_user, type) %>

--- a/app/views/reactions/_reactions.html.erb
+++ b/app/views/reactions/_reactions.html.erb
@@ -1,0 +1,33 @@
+<%# 掲示板詳細でのリアクションボタン列。memory は必須ローカル変数。 %>
+<div class="flex items-center gap-2 flex-wrap">
+  <% Reaction.reaction_types.keys.each do |type| %>
+    <% if memory.reactable_by?(current_user) %>
+      <% if memory.reacted_by?(current_user, type) %>
+        <%= button_to public_memory_reaction_path(memory, type),
+                      method: :delete,
+                      class: reaction_button_class(true),
+                      form: { class: "inline-block" } do %>
+          <span><%= reaction_emoji(type) %></span>
+          <span class="text-xs"><%= memory.reaction_count(type) %></span>
+        <% end %>
+      <% else %>
+        <%= button_to public_memory_reactions_path(memory),
+                      method: :post,
+                      params: { reaction_type: type },
+                      class: reaction_button_class(false),
+                      form: { class: "inline-block" } do %>
+          <span><%= reaction_emoji(type) %></span>
+          <span class="text-xs"><%= memory.reaction_count(type) %></span>
+        <% end %>
+      <% end %>
+    <% else %>
+      <button type="button"
+              class="<%= reaction_button_class(memory.reacted_by?(current_user, type)) %>"
+              disabled
+              title="<%= disabled_reaction_title(memory) %>">
+        <span><%= reaction_emoji(type) %></span>
+        <span class="text-xs"><%= memory.reaction_count(type) %></span>
+      </button>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/reactions/create.turbo_stream.erb
+++ b/app/views/reactions/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "reactions_#{@memory.id}" do %>
+  <%= render "reactions/reactions", memory: @memory %>
+<% end %>

--- a/app/views/reactions/destroy.turbo_stream.erb
+++ b/app/views/reactions/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "reactions_#{@memory.id}" do %>
+  <%= render "reactions/reactions", memory: @memory %>
+<% end %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       user: ユーザー
       memory: 思い出
+      reaction: リアクション
     attributes:
       user:
         email: メールアドレス
@@ -17,6 +18,14 @@ ja:
         image: 画像
       user_family_group:
         role: 役割
+      reaction:
+        reaction_type: リアクションの種類
+    errors:
+      models:
+        reaction:
+          attributes:
+            base:
+              own_post: 自分の投稿にはリアクションできません
   enums:
     memory:
       visibility:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -80,6 +80,13 @@ ja:
       subtitle: 公開されたみんなのミニメモリーを見られます
     show:
       return_to_list: 一覧に戻る
+  reactions:
+    alert:
+      already_exists: すでにそのリアクションは存在します
+      invalid_type: 不正なリアクション種別です
+    disabled_reason:
+      own_post: 自分の投稿にはリアクションできません
+      not_logged_in: ログインするとリアクションできます
   mypage:
     account_title: プロフィール
     account_subtitle: アカウント情報を確認できます

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,12 @@ Rails.application.routes.draw do
   resources :memories, param: :uuid, only: %i[index new create show edit update destroy]
 
   # 掲示板 - uuidをURLパラメータとして使用するため、param: :uuidを指定
-  resources :public_memories, param: :uuid, only: %i[index show]
+  resources :public_memories, param: :uuid, only: %i[index show] do
+    # リアクション - 識別子に reaction_type(enum キー) を使う。
+    # POST   /public_memories/:public_memory_uuid/reactions                 → create
+    # DELETE /public_memories/:public_memory_uuid/reactions/:reaction_type  → destroy
+    resources :reactions, only: %i[create destroy], param: :reaction_type
+  end
 
   # 家族のミニメモリ - 家族メンバー横断のフィード（unlisted + published）。
   # 詳細表示は既存の memories#show（MemoryPolicy#show? が家族メンバー閲覧を許可）に集約する。

--- a/db/migrate/20260516160637_create_reactions.rb
+++ b/db/migrate/20260516160637_create_reactions.rb
@@ -3,7 +3,7 @@ class CreateReactions < ActiveRecord::Migration[7.2]
     create_table :reactions do |t|
       t.references :user, null: false, foreign_key: true
       t.references :memory, null: false, foreign_key: true
-      t.integer :reaction_type
+      t.integer :reaction_type, null: false
 
       t.timestamps
     end

--- a/db/migrate/20260516160637_create_reactions.rb
+++ b/db/migrate/20260516160637_create_reactions.rb
@@ -1,0 +1,13 @@
+class CreateReactions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :reactions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :memory, null: false, foreign_key: true
+      t.integer :reaction_type
+
+      t.timestamps
+    end
+
+    add_index :reactions, [ :user_id, :memory_id, :reaction_type ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_20_145827) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_16_160637) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -74,6 +74,17 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_20_145827) do
     t.index ["uuid"], name: "index_memories_on_uuid", unique: true
   end
 
+  create_table "reactions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "memory_id", null: false
+    t.integer "reaction_type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["memory_id"], name: "index_reactions_on_memory_id"
+    t.index ["user_id", "memory_id", "reaction_type"], name: "index_reactions_on_user_id_and_memory_id_and_reaction_type", unique: true
+    t.index ["user_id"], name: "index_reactions_on_user_id"
+  end
+
   create_table "user_family_groups", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "family_group_id", null: false
@@ -105,6 +116,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_20_145827) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "invitations", "family_groups"
   add_foreign_key "memories", "users"
+  add_foreign_key "reactions", "memories"
+  add_foreign_key "reactions", "users"
   add_foreign_key "user_family_groups", "family_groups"
   add_foreign_key "user_family_groups", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,7 +77,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_16_160637) do
   create_table "reactions", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "memory_id", null: false
-    t.integer "reaction_type"
+    t.integer "reaction_type", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["memory_id"], name: "index_reactions_on_memory_id"

--- a/docs/pundit-design.md
+++ b/docs/pundit-design.md
@@ -15,7 +15,10 @@
 | 5 | #212 | InvitationsController に Pundit 適用 |
 | 6 | #213 | Dashboard / Api::MemoryGames で `policy_scope` 適用 |
 | 7 | #215 | `verify_authorized` 有効化 |
-| 8 | #218 | メンバーシップ管理（役割変更 / 自己脱退 / owner kick） |
+| 8 | #218 | メンバーシップ管理（役割変更 / 自己脱退） |
+| 9 | #220 | owner kick + 本ドキュメント追加 |
+| 10 | #223 | `Memory#visibility#unlisted` を有効化（家族メンバー閲覧可） |
+| 11 | #225 | 家族フィード（`FamilyFeedMemoryPolicy` + `FamilyMemoriesController`） |
 
 各 PR を develop に積み、揃った後 main に一斉リリース。
 
@@ -80,6 +83,7 @@ Memory には公開フィード（`PublicMemoriesController`）があるため�
 | `InvitationsController#show` | token 検証のみで Pundit を経由しない設計 |
 | `DashboardController` 全体 | `policy_scope` のみで `authorize` を呼ばない |
 | `Api::MemoryGamesController` 全体 | 同上 |
+| `FamilyMemoriesController` 全体 | `policy_scope` のみで `authorize` を呼ばない |
 | `MypagesController` 全体 | 自分自身のプロフィール表示のため認可不要 |
 | `MemoryGamesController` 全体 | ゲーム画面の表示のみで認可対象レコードが無い |
 | `StaticPagesController` 全体 | 未認証ランディング |
@@ -89,7 +93,7 @@ Devise 系コントローラは `ApplicationController` の `after_action :verif
 
 ### 4. 認可とビジネスルールの分離
 
-`UserFamilyGroup` モデルの「最後の owner 保護」は Policy ではなく **モデル層の validation / before_destroy** で実装している:
+`UserFamilyGroup` モデルの「最後の owner 保護」は Policy ではなく **モデル層の validation / before_destroy** で実装:
 
 ```ruby
 # app/models/user_family_group.rb
@@ -106,7 +110,7 @@ before_destroy :ensure_at_least_one_owner_remains_after_leave
 
 ### 5. ビューの Policy 一元化
 
-ビューでは `policy(record).action?` を直接呼ぶ。コントローラに `@is_owner` のような真偽値を入れるインスタンス変数を作っていない。
+ビューでは `policy(record).action?` を直接呼ぶ。コントローラに `@is_owner` のような真偽値を入れるインスタンス変数を作らない方針にした。
 
 実装根拠（`app/views/family_groups/show.html.erb`）:
 - 招待リンク発行カードの表示判定: `<% if policy(@family_group).update? %>`
@@ -119,7 +123,7 @@ before_destroy :ensure_at_least_one_owner_remains_after_leave
 
 ### 6. 並行制御（コントローラ層で `lock!`）
 
-`UserFamilyGroupsController#update` / `#destroy` は `transaction { @family_group.lock!; ... }` で family_group 行を pessimistic lock している:
+`UserFamilyGroupsController#update` / `#destroy` は `transaction { @family_group.lock!; ... }` で family_group 行を 排他ロック:
 
 ```ruby
 def update
@@ -135,7 +139,7 @@ def update
 end
 ```
 
-ロック対象が family_group 行である理由: 同一グループへのメンバー変更は **同じ family_group 行** を介して直列化される。各トランザクションが「異なる owner 行」を個別にロックしても両者は競合せず race condition は解決しないため、グループ単位でロックしている。
+ロック対象が family_group 行である理由: 同一グループへのメンバー変更は **同じ family_group 行** を介して直列化される。各トランザクションが「異なる owner 行」を個別にロックしても両者は競合しない。グループ単位でロック。
 
 なお model の validation / before_destroy 自体は `lock!` を呼ばない（純粋な存在判定のみ）。
 
@@ -155,6 +159,54 @@ def kick?    = group_owner? && !self_membership?   # 除名ボタン表示
 - self-leave 時 → `mypage_path`
 - owner kick 時 → `family_group_path`
 
+### 8. visibility ごとの閲覧範囲を `show?` に集約
+
+`Memory#visibility` は 3 値（`private_only` / `unlisted` / `published`）。閲覧可否は `MemoryPolicy#show?` 内の論理和で表現する:
+
+```ruby
+def show? = record.published? || owner? || (record.unlisted? && family_member_of_owner?)
+```
+
+判定経路を1メソッドに集約することで、詳細ページ（`MemoriesController#show`）が visibility に関わらず同じ `authorize @memory` で動く。家族フィードから unlisted 投稿を開いても、本人が `published` を開いても、未ログインユーザーが `published` を開いても、入口は同じ。
+
+`family_member_of_owner?` は「自分の所属グループと投稿者の所属グループに重複があるか」を 1 クエリで判定する:
+
+```ruby
+def family_member_of_owner?
+  return false if user.nil?
+  user.family_groups.where(id: record.user.family_groups.select(:id)).exists?
+end
+```
+
+「1 ユーザー 1 グループ」制約下では実質「同じ家族グループに属しているか」と等価。`pluck` で配列に展開せずサブクエリとして渡している（DB内でクエリが完結されるため）。
+
+### 9. Scope 専用 Policy（同一モデルで Scope を切り替える）
+
+家族フィード（`FamilyMemoriesController#index`）は「家族メンバーが投稿した `unlisted` + `published`」を返す。これは `MemoryPolicy::Scope` の「自分の投稿のみ」とは別軸の集合。両方を `MemoryPolicy::Scope` 内で分岐させると Scope が肥大化するため、**Scope 専用の Policy** として `FamilyFeedMemoryPolicy` を切り出した:
+
+```ruby
+class FamilyFeedMemoryPolicy < ApplicationPolicy
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope.none if user.nil?
+      family_user_ids = UserFamilyGroup
+                          .where(family_group_id: user.family_groups.select(:id))
+                          .select(:user_id)
+      scope.where(user_id: family_user_ids, visibility: [ :unlisted, :published ])
+    end
+  end
+end
+```
+
+action 述語（`show?` 等）は持たない。controller 側で Pundit の `policy_scope_class:` オプションを使い、`Memory` モデルに対して別 Scope を明示指定する:
+
+```ruby
+@memories = policy_scope(Memory, policy_scope_class: FamilyFeedMemoryPolicy::Scope)
+              .with_attached_image.includes(:user).order(created_at: :desc)
+```
+
+詳細ページは `MemoriesController#show` に集約する（`MemoryPolicy#show?` が家族メンバー閲覧を許可する）ため、`FamilyMemoriesController` は index のみで完結する。
+
 ---
 
 ## `verify_authorized`
@@ -167,14 +219,7 @@ after_action :verify_authorized, unless: :devise_controller?
 
 各アクションで `authorize` が呼ばれていない場合、Pundit が `Pundit::AuthorizationNotPerformedError` を発生させる。`Pundit::NotAuthorizedError`（実行時の認可拒否）とは別の例外で、認可呼び忘れの検出に使う。
 
-`verify_policy_scoped` は導入していない。
-
----
-
-## トレードオフ
-
-- **未認可メッセージの汎用化**: `config/locales/pundit.ja.yml` は `not_authorized: 操作する権限がありません` のみ。Pundit 導入前に `FamilyGroupsController#destroy` 内に書かれていた「家族グループの削除はオーナーのみ可能です」のようなアクション固有のメッセージは、認可拒否経路では出なくなった。
-- **早期ブロック**: 既所属ユーザーが `/family_groups/new` を開いた時点で `FamilyGroupPolicy#new?`（`= create?`）が `user.user_family_groups.empty?` を返さず `Pundit::NotAuthorizedError` で弾かれる。`/family_groups` への POST 時の `RecordNotUnique` rescue も残してあるが、UI フロー上はそこに到達しない。
+チェック漏れを防ぐための`verify_policy_scoped` は導入していない。
 
 ---
 
@@ -182,8 +227,9 @@ after_action :verify_authorized, unless: :devise_controller?
 
 ```
 app/policies/
-├── application_policy.rb       基底クラス（全述語デフォルト false / Scope#resolve は NoMethodError）
+├── application_policy.rb           基底クラス（全述語デフォルト false / Scope#resolve は NoMethodError）
 ├── memory_policy.rb
+├── family_feed_memory_policy.rb    Scope 専用（policy_scope_class で指定）
 ├── family_group_policy.rb
 ├── user_family_group_policy.rb
 └── invitation_policy.rb
@@ -192,13 +238,3 @@ app/controllers/application_controller.rb  # Pundit::Authorization include / ver
 config/locales/pundit.ja.yml                # 未認可メッセージ I18n
 ```
 
----
-
-## 今後の判断のためのデフォルト原則
-
-1. 新規モデル → **Policy + Scope を最初に書く**（コントローラ適用は後でも可）
-2. **「機微 vs 公開」を最初に判断** → 機微なら二段防衛
-3. **認可（誰が）かビジネスルール（整合性）か** を意識してレイヤを選ぶ
-4. **ビューでは `policy(...)` を直接呼ぶ**。コントローラに `@is_xxx` ivar を作らない
-5. **並行性が重要な操作** はコントローラ層で `transaction { lock!; ... }`
-6. **Pundit を通さない判断** をする時は `skip_after_action :verify_authorized` で意図を明示

--- a/test/controllers/reactions_controller_test.rb
+++ b/test/controllers/reactions_controller_test.rb
@@ -1,0 +1,4 @@
+require "test_helper"
+
+class ReactionsControllerTest < ActionDispatch::IntegrationTest
+end

--- a/test/fixtures/reactions.yml
+++ b/test/fixtures/reactions.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  memory: one
+  reaction_type: 1
+
+two:
+  user: two
+  memory: two
+  reaction_type: 2

--- a/test/models/reaction_test.rb
+++ b/test/models/reaction_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ReactionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要                                                      
  - 掲示板（公開ミニメモリ）詳細ページに 5 種類の絵文字リアクション機能（👍 / 👏 / ❤️  / 😂 / 🥺）を追加                                                                                                                                     
  - リアクションの押下・取消しを **Turbo Stream** で AJAX 化（ページ全体再読込なし）                                                                                                                                                        
  - 日本語ハードコードを **i18n 化**（model error / controller alert / view tooltip）                                                                                                                                                       
  - `docs/pundit-design.md` を最新 PR（#220 / #223 / #225）の内容で更新                                                                                                                                                                     
                                                                                                                                                                                                                                            
  ## 関連 PR                                                                                                                                                                                                                                
  - #228 docs: Pundit 設計メモに #220 / #223 / #225 の判断を追記                                                                                                                                                                            
  - #231 feat: 掲示板にリアクション機能を追加                                                                                                                                                                                               
  - #232 feat: リアクション操作を Turbo Stream で部分更新化 + i18n 化
                                                                                                                                                                                                                                            
  ## 主な変更点                                                                                                     
                                                                                                                                                                                                                                            
  ### 認可（Pundit）                                                                                                
  - `MemoryPolicy#react?` 追加。判定ロジックは `Memory#reactable_by?` に集約
  - `MemoryPolicy#owner?` も `Memory#owned_by?` に統一                                                                                                                                                                                      
  - `ReactionPolicy#destroy?` は押下した本人のみ許可
                                                                                                                                                                                                                                            
  ### モデル / DB                                                                                                   
  - `(user_id, memory_id, reaction_type)` の複合 **unique index** で重複押下を DB レベルで防御                                                                                                                                              
  - `Reaction` モデル: `enum reaction_type` 5 種類 + uniqueness validation + 自己投稿禁止 validation（二重防御）                                                                                                                            
  - `Memory` に `has_many :reactions, dependent: :destroy` と判定メソッド 4 つ                                                                                                                                                              
    （`owned_by?` / `reactable_by?` / `reacted_by?` / `reaction_count`）                                                                                                                                                                    
  - `User` に `has_many :reactions, dependent: :destroy`                                                                                                                                                                                    
                                                                                                                                                                                                                                            
  ### コントローラ / ルーティング                                                                                                                                                                                                           
  - `public_memories` 配下に nested で `resources :reactions, only: %i[create destroy], param: :reaction_type`                                                                                                                              
  - `ReactionsController#create` で `MemoryPolicy#react?` 経由、`#destroy` で `ReactionPolicy#destroy?` 経由        
  - `respond_to do |format|` で turbo_stream / html を分岐し、JS 無効時のフォールバックを維持                                                                                                                                               
                                                                                                                                                                                                                                            
  ### ビュー / UI                                                                                                                                                                                                                           
  - 掲示板詳細ページにリアクションボタン列を追加                                                                                                                                                                                            
  - 投稿者本人 / 未ログイン時は disabled ボタンを表示（理由を title 属性で出し分け）                                                                                                                                                        
  - `app/views/reactions/_reactions.html.erb` の最外殻に `id="reactions_<memory.id>"` を付与し Turbo Stream の差し替え対象を明示                                                                                                            
  - 編集ボタンの可視判定を `current_user == @memory.user` から `policy(@memory).edit?` に置換（`memories/show` と `public_memories/show`）                                                                                                  
                                                                                                                                                                                                                                            
  ### i18n                                                                                                                                                                                                                                  
  - `config/locales/activerecord/ja.yml`: reaction model / attributes / errors キー追加                                                                                                                                                     
  - `config/locales/views/ja.yml`: `reactions.alert.*` / `reactions.disabled_reason.*` キー追加                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                            
  ### ドキュメント                                                                                                                                                                                                                          
  - `docs/pundit-design.md` の段階導入表に #220 / #223 / #225 を追記                                                                                                                                                                        
  - `skip_after_action :verify_authorized` 対象表に `FamilyMemoriesController` を追加                                                                                                                                                       
  - 設計判断セクションに「visibility 別の閲覧範囲を `show?` に集約」「Scope 専用 Policy」を追加                                                                                                                                             
                                                                                                                                                                                
                                                                                                                                                                                                                                            
  ## 動作確認済み（develop 上）                                                                                                                                                                                                             
  - [x] 他人の published 投稿に 5 種類すべてリアクション押下できる                                                                                                                                                                          
  - [x] 同じ種類を再度押すと取り消される                                                                            
  - [x] 自分の投稿には disabled で押せない                                                                                                                                                                                                  
  - [x] 未ログイン時も disabled で押せない                                                                                                                                                                      
  - [x] Turbo Stream 経路でリアクション部分のみ差し替わる（スクロール位置維持）                                                                                                                                                                                                                                                                                                                                            

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 投稿に対してリアクション機能（👍、👏、❤️、😄、😭）を追加しました。

* **改善**
  * リアクション操作のUIを改良し、権限に基づいた表示制御を実装しました。
  * リアクション関連の認可・検証ロジックを強化しました。

* **ドキュメント**
  * 認可設計ドキュメントを更新しました。

* **テスト**
  * テストの基本構成を整備しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tantp-1111/mini_memory/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->