### PR TITLE
家族グループ配下にこども設定機能を追加 

### DIFF
--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -1,0 +1,64 @@
+class ChildrenController < ApplicationController
+  before_action :set_family_group
+  before_action :set_child, only: %i[edit update destroy]
+
+  def index
+    @children = policy_scope(@family_group.children).order(:birthday)
+    authorize @family_group, :show?
+  end
+
+  def new
+    @child = @family_group.children.new
+    authorize @child
+  end
+
+  def create
+    @child = @family_group.children.new(child_params)
+    authorize @child
+
+    if @child.save
+      redirect_to family_group_children_path(@family_group),
+                  notice: t("defaults.flash_message.created", model: Child.model_name.human)
+    else
+      flash.now[:alert] = t("defaults.flash_message.not_created", model: Child.model_name.human)
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    authorize @child
+  end
+
+  def update
+    authorize @child
+    if @child.update(child_params)
+      redirect_to family_group_children_path(@family_group),
+                  notice: t("defaults.flash_message.updated", model: Child.model_name.human)
+    else
+      flash.now[:alert] = t("defaults.flash_message.not_updated", model: Child.model_name.human)
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    authorize @child
+    @child.destroy!
+    redirect_to family_group_children_path(@family_group),
+                notice: t("defaults.flash_message.deleted", model: Child.model_name.human)
+  end
+
+  private
+
+  # 非メンバーには 404（存在を隠す）、メンバー以上には authorize で操作種別を判定する二段防衛。
+  def set_family_group
+    @family_group = policy_scope(FamilyGroup).find_by!(uuid: params[:family_group_uuid])
+  end
+
+  def set_child
+    @child = @family_group.children.find_by!(uuid: params[:uuid])
+  end
+
+  def child_params
+    params.require(:child).permit(:name, :birthday)
+  end
+end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -1,0 +1,17 @@
+class Child < ApplicationRecord
+  belongs_to :family_group
+
+  validates :name, presence: true, length: { maximum: 30 }
+  validate :birthday_not_in_future, if: -> { birthday.present? }
+
+  # URLのパラメータとしてuuidを使用
+  def to_param
+    uuid
+  end
+
+  private
+
+  def birthday_not_in_future
+    errors.add(:birthday, :in_future) if birthday > Date.current
+  end
+end

--- a/app/models/family_group.rb
+++ b/app/models/family_group.rb
@@ -2,6 +2,7 @@ class FamilyGroup < ApplicationRecord
   has_many :user_family_groups, dependent: :destroy
   has_many :users, through: :user_family_groups
   has_many :invitations, dependent: :destroy
+  has_many :children, dependent: :destroy
 
   validates :name, presence: true
 

--- a/app/policies/child_policy.rb
+++ b/app/policies/child_policy.rb
@@ -1,0 +1,28 @@
+class ChildPolicy < ApplicationPolicy
+  # 親リソース(FamilyGroup) のメンバー検証は controller の before_action で実施。
+  # ChildPolicy では「オーナーだけが書き込み可能」を表現する。
+  def index?   = true
+  def show?    = true
+  def create?  = owner_of_record_group?
+  def update?  = owner_of_record_group?
+  def destroy? = owner_of_record_group?
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope.none if user.nil?
+      # 将来「1ユーザー複数グループ」になっても壊れないよう pluck で配列取得
+      group_ids = user.user_family_groups.pluck(:family_group_id)
+      return scope.none if group_ids.empty?
+      scope.where(family_group_id: group_ids)
+    end
+  end
+
+  private
+
+  def owner_of_record_group?
+    return false if user.nil?
+    user.user_family_groups.exists?(
+      family_group_id: record.family_group_id, role: :owner
+    )
+  end
+end

--- a/app/views/children/_form.html.erb
+++ b/app/views/children/_form.html.erb
@@ -1,0 +1,25 @@
+<%= form_with model: [@family_group, @child] do |f| %>
+  <%= render "shared/error_messages", object: f.object %>
+
+  <div class="form-control gap-1">
+    <%= f.label :name, class: "label py-0" do %>
+      <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60"><%= t("activerecord.attributes.child.name") %></span>
+    <% end %>
+    <%= f.text_field :name,
+          placeholder: t("children.form.name_placeholder"),
+          class: "input input-bordered input-sm bg-base-200/50 focus:bg-base-100 focus:input-primary transition-all duration-200 w-full" %>
+  </div>
+
+  <div class="form-control gap-1">
+    <%= f.label :birthday, class: "label py-0" do %>
+      <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60"><%= t("activerecord.attributes.child.birthday") %></span>
+    <% end %>
+    <%= f.date_field :birthday,
+          class: "input input-bordered input-sm bg-base-200/50 focus:bg-base-100 focus:input-primary transition-all duration-200 w-full" %>
+  </div>
+
+  <div class="flex justify-end gap-2 pt-1 border-t border-base-200">
+    <%= link_to t("helpers.submit.cancel"), family_group_children_path(@family_group), class: "btn btn-ghost btn-sm" %>
+    <%= f.submit class: "btn btn-primary btn-sm px-6" %>
+  </div>
+<% end %>

--- a/app/views/children/edit.html.erb
+++ b/app/views/children/edit.html.erb
@@ -1,0 +1,26 @@
+<div class="min-h-screen bg-base-200 flex justify-center py-6 px-4">
+  <div class="fixed inset-0 overflow-hidden pointer-events-none">
+    <div class="absolute -top-24 -right-24 w-96 h-96 rounded-full opacity-10 bg-primary blur-3xl"></div>
+    <div class="absolute -bottom-24 -left-24 w-96 h-96 rounded-full opacity-10 bg-secondary blur-3xl"></div>
+  </div>
+
+  <div class="relative w-full max-w-2xl">
+    <div class="flex items-center gap-3 mb-4">
+      <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-primary/10 shrink-0">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-primary" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z" />
+        </svg>
+      </div>
+      <div>
+        <h1 class="text-xl font-bold tracking-tight leading-tight"><%= t("children.edit.title") %></h1>
+        <p class="text-base-content/50 text-xs"><%= t("children.edit.subtitle") %></p>
+      </div>
+    </div>
+
+    <div class="card bg-base-100 shadow-2xl border border-base-200">
+      <div class="card-body p-6 gap-4">
+        <%= render "form" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/children/index.html.erb
+++ b/app/views/children/index.html.erb
@@ -1,0 +1,75 @@
+<div class="min-h-screen bg-base-200 flex justify-center py-6 px-4">
+  <div class="fixed inset-0 overflow-hidden pointer-events-none">
+    <div class="absolute -top-24 -right-24 w-96 h-96 rounded-full opacity-10 bg-primary blur-3xl"></div>
+    <div class="absolute -bottom-24 -left-24 w-96 h-96 rounded-full opacity-10 bg-secondary blur-3xl"></div>
+  </div>
+
+  <div class="relative w-full max-w-2xl">
+    <div class="flex items-center gap-3 mb-4">
+      <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-primary/10 shrink-0">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-primary" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z" />
+        </svg>
+      </div>
+      <div class="flex-1">
+        <h1 class="text-xl font-bold tracking-tight leading-tight"><%= t("children.index.title") %></h1>
+        <p class="text-base-content/50 text-xs"><%= t("children.index.subtitle", group_name: @family_group.name) %></p>
+      </div>
+      <% if policy(Child.new(family_group: @family_group)).create? %>
+        <%= link_to new_family_group_child_path(@family_group), class: "btn btn-primary btn-sm" do %>
+          + <%= t("children.index.add") %>
+        <% end %>
+      <% end %>
+    </div>
+
+    <% unless policy(Child.new(family_group: @family_group)).create? %>
+      <div class="alert alert-info alert-soft text-xs mb-4">
+        <%= t("children.index.member_notice") %>
+      </div>
+    <% end %>
+
+    <% if @children.empty? %>
+      <div class="card bg-base-100 shadow-2xl border border-base-200">
+        <div class="card-body p-6 gap-2 items-center text-center">
+          <p class="text-base-content/50 text-sm"><%= t("children.index.empty") %></p>
+        </div>
+      </div>
+    <% else %>
+      <div class="grid gap-3">
+        <% @children.each do |child| %>
+          <div class="card bg-base-100 shadow-xl border border-base-200">
+            <div class="card-body p-4 flex-row items-center gap-3">
+              <div class="inline-flex items-center justify-center w-10 h-10 rounded-full bg-primary/10 shrink-0">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-primary" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z" />
+                </svg>
+              </div>
+              <div class="flex-1 min-w-0">
+                <p class="font-semibold text-base truncate"><%= child.name %></p>
+                <% if child.birthday.present? %>
+                  <p class="text-base-content/50 text-xs">
+                    <%= l(child.birthday, format: :long) %>
+                  </p>
+                <% end %>
+              </div>
+              <% if policy(child).update? %>
+                <%= link_to t("helpers.submit.edit"), edit_family_group_child_path(@family_group, child), class: "btn btn-ghost btn-xs" %>
+              <% end %>
+              <% if policy(child).destroy? %>
+                <%= button_to t("helpers.submit.delete"),
+                              family_group_child_path(@family_group, child),
+                              method: :delete,
+                              form: { data: { turbo_confirm: t("defaults.delete_confirm") } },
+                              class: "btn btn-ghost btn-xs text-error" %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+
+    <div class="flex justify-end mt-4">
+      <%= link_to t("children.index.back_to_mypage"), mypage_path, class: "btn btn-ghost btn-sm" %>
+    </div>
+  </div>
+</div>

--- a/app/views/children/new.html.erb
+++ b/app/views/children/new.html.erb
@@ -1,0 +1,26 @@
+<div class="min-h-screen bg-base-200 flex justify-center py-6 px-4">
+  <div class="fixed inset-0 overflow-hidden pointer-events-none">
+    <div class="absolute -top-24 -right-24 w-96 h-96 rounded-full opacity-10 bg-primary blur-3xl"></div>
+    <div class="absolute -bottom-24 -left-24 w-96 h-96 rounded-full opacity-10 bg-secondary blur-3xl"></div>
+  </div>
+
+  <div class="relative w-full max-w-2xl">
+    <div class="flex items-center gap-3 mb-4">
+      <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-primary/10 shrink-0">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-primary" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z" />
+        </svg>
+      </div>
+      <div>
+        <h1 class="text-xl font-bold tracking-tight leading-tight"><%= t("children.new.title") %></h1>
+        <p class="text-base-content/50 text-xs"><%= t("children.new.subtitle") %></p>
+      </div>
+    </div>
+
+    <div class="card bg-base-100 shadow-2xl border border-base-200">
+      <div class="card-body p-6 gap-4">
+        <%= render "form" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/dashboard/top.html.erb
+++ b/app/views/dashboard/top.html.erb
@@ -99,8 +99,8 @@
       <%= link_to memory_game_path, class: "card bg-base-100 shadow-xl hover:shadow-2xl hover:-translate-y-1 transition border-l-4 border-accent" do %>
         <div class="card-body gap-3">
           <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-accent/10 shrink-0 self-start">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-accent" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z" />
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-accent fill-current" viewBox="0 0 24 24">
+              <path d="M21.58,16.09l-1.09-7.66C20.21,6.46,18.52,5,16.53,5H7.47C5.48,5,3.79,6.46,3.51,8.43l-1.09,7.66C2.2,17.63,3.39,19,4.94,19h0c0.68,0,1.32-0.27,1.8-0.75L9,16h6l2.25,2.25c0.48,0.48,1.13,0.75,1.8,0.75h0C20.61,19,21.8,17.63,21.58,16.09z M11,11H9v2H8v-2H6v-1h2V8h1v2h2V11z M15,10c-0.55,0-1-0.45-1-1c0-0.55,0.45-1,1-1s1,0.45,1,1C16,9.55,15.55,10,15,10z M17,13c-0.55,0-1-0.45-1-1c0-0.55,0.45-1,1-1s1,0.45,1,1C18,12.55,17.55,13,17,13z"/>
             </svg>
           </div>
           <div>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -95,5 +95,38 @@
       </div>
     <% end %>
 
+    <!-- こどもセクション -->
+    <div class="flex items-center gap-3 mt-6 mb-4">
+      <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-primary/10 shrink-0">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-primary" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z" />
+        </svg>
+      </div>
+      <div>
+        <h2 class="text-xl font-bold tracking-tight leading-tight"><%= t('mypage.children.title') %></h2>
+        <p class="text-base-content/50 text-xs"><%= t('mypage.children.subtitle') %></p>
+      </div>
+    </div>
+
+    <% if @family_group %>
+      <div class="card bg-base-100 shadow-2xl border border-base-200">
+        <div class="card-body p-6 gap-4">
+          <p class="text-base-content/70 text-sm">
+            <%= t('mypage.children.count', count: @family_group.children.count) %>
+          </p>
+          <div class="flex justify-end pt-1 border-t border-base-200">
+            <%= link_to t('mypage.children.view_list'), family_group_children_path(@family_group), class: "btn btn-primary btn-sm px-6" %>
+          </div>
+        </div>
+      </div>
+    <% else %>
+      <div class="card bg-base-100 shadow-2xl border border-base-200">
+        <div class="card-body p-6 gap-2 items-center text-center">
+          <p class="text-base-content/50 text-sm"><%= t('mypage.children.requires_group') %></p>
+          <p class="text-base-content/40 text-xs"><%= t('mypage.children.requires_group_subtitle') %></p>
+        </div>
+      </div>
+    <% end %>
+
   </div>
 </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -45,8 +45,8 @@
       <%# 楽しむボタン %>
       <%= link_to memory_game_path, class: "flex flex-col items-center justify-center text-xs #{active_if("memory_games")}" do %>
         <span class="text-xl">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z" />
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 fill-current" viewBox="0 0 24 24">
+              <path d="M21.58,16.09l-1.09-7.66C20.21,6.46,18.52,5,16.53,5H7.47C5.48,5,3.79,6.46,3.51,8.43l-1.09,7.66C2.2,17.63,3.39,19,4.94,19h0c0.68,0,1.32-0.27,1.8-0.75L9,16h6l2.25,2.25c0.48,0.48,1.13,0.75,1.8,0.75h0C20.61,19,21.8,17.63,21.58,16.09z M11,11H9v2H8v-2H6v-1h2V8h1v2h2V11z M15,10c-0.55,0-1-0.45-1-1c0-0.55,0.45-1,1-1s1,0.45,1,1C16,9.55,15.55,10,15,10z M17,13c-0.55,0-1-0.45-1-1c0-0.55,0.45-1,1-1s1,0.45,1,1C18,12.55,17.55,13,17,13z"/>
           </svg>
         </span>
         <span><%= t('footer.enjoy') %></span>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -4,6 +4,7 @@ ja:
       user: ユーザー
       memory: 思い出
       reaction: リアクション
+      child: こども
     attributes:
       user:
         email: メールアドレス
@@ -20,12 +21,19 @@ ja:
         role: 役割
       reaction:
         reaction_type: リアクションの種類
+      child:
+        name: 名前
+        birthday: 生年月日
     errors:
       models:
         reaction:
           attributes:
             base:
               own_post: 自分の投稿にはリアクションできません
+        child:
+          attributes:
+            birthday:
+              in_future: は未来の日付を指定できません
   enums:
     memory:
       visibility:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -87,11 +87,34 @@ ja:
     disabled_reason:
       own_post: 自分の投稿にはリアクションできません
       not_logged_in: ログインするとリアクションできます
+  children:
+    index:
+      title: こども一覧
+      subtitle: "「%{group_name}」のこどもを管理できます"
+      add: こどもを追加
+      empty: まだこどもが登録されていません
+      member_notice: こどもの追加・編集はグループのオーナーのみ可能です
+      back_to_mypage: マイページに戻る
+    new:
+      title: こども新規登録
+      subtitle: 家族グループにこどもを追加します
+    edit:
+      title: こども編集
+      subtitle: こどもの情報を編集します
+    form:
+      name_placeholder: こどもの名前を入力
   mypage:
     account_title: プロフィール
     account_subtitle: アカウント情報を確認できます
     user_name: ユーザー名
     avatar: アバター画像
+    children:
+      title: こども
+      subtitle: 家族で共有するこどもを管理できます
+      count: "%{count}人登録されています"
+      view_list: こども一覧を見る
+      requires_group: こどもの登録には家族グループへの所属が必要です
+      requires_group_subtitle: 家族グループを作成または参加してください
     family_group:
       title: 家族グループ
       subtitle: グループを作成・管理できます

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,9 @@ Rails.application.routes.draw do
   resources :family_groups, param: :uuid, only: %i[new create update show destroy] do
     # メンバーシップ操作（役割変更・脱退）。member 中間テーブルのため id は数値 ID。
     resources :user_family_groups, only: %i[update destroy]
+
+    # こども管理 - uuidをURLパラメータとして使用するため、param: :uuidを指定
+    resources :children, param: :uuid, only: %i[index new create edit update destroy]
   end
 
   get "memory_game" => "memory_games#show", as: :memory_game

--- a/db/migrate/20260520143244_create_children.rb
+++ b/db/migrate/20260520143244_create_children.rb
@@ -1,0 +1,14 @@
+class CreateChildren < ActiveRecord::Migration[7.2]
+  def change
+    create_table :children do |t|
+      t.uuid :uuid, default: "gen_random_uuid()", null: false
+      t.references :family_group, null: false, foreign_key: true
+      t.string :name, null: false
+      t.date :birthday
+
+      t.timestamps
+    end
+
+    add_index :children, :uuid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_16_160637) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_20_143244) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -41,6 +41,17 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_16_160637) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "children", force: :cascade do |t|
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.bigint "family_group_id", null: false
+    t.string "name", null: false
+    t.date "birthday"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["family_group_id"], name: "index_children_on_family_group_id"
+    t.index ["uuid"], name: "index_children_on_uuid", unique: true
   end
 
   create_table "family_groups", force: :cascade do |t|
@@ -114,6 +125,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_16_160637) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "children", "family_groups"
   add_foreign_key "invitations", "family_groups"
   add_foreign_key "memories", "users"
   add_foreign_key "reactions", "memories"


### PR DESCRIPTION
## 概要                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                          
家族グループ配下に **こども(Child)** を管理する機能を追加。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                          
  ## 変更ファイル一覧                                                                                                                                                                                                                       
                                                                                                                                                                                                                                          
  | ファイル | 種別 | 変更理由 |                                                                                                                                                                                                            
  |---|---|---|
  | `db/migrate/20260520143244_create_children.rb` | 新規 | children テーブル(uuid, family_group_id, name, birthday) |                                                                                                                      
  | `db/schema.rb` | 更新 | 上記マイグレーション反映 |                                                                                                                                                                                      
  | `app/models/child.rb` | 新規 | バリデーション(名前必須・30字、生年月日未来不可)、`to_param` で uuid |                                                                                                                                   
  | `app/models/family_group.rb` | 更新 | `has_many :children, dependent: :destroy` |                                                                                                                                                       
  | `app/policies/child_policy.rb` | 新規 | メンバー閲覧可・オーナーのみ書き込み可、Scope は `pluck` で複数グループ耐性 |                                                                                                                   
  | `config/routes.rb` | 更新 | `family_groups` にネストして `resources :children` |                                                                                                                                                        
  | `app/controllers/children_controller.rb` | 新規 | CRUD + `policy_scope(FamilyGroup)` による 404 二段防衛 |     
  | `app/views/children/{index,new,edit,_form}.html.erb` | 新規 | Tailwind + daisyUI ベース |                                                                                                                                               
  | `app/views/mypages/show.html.erb` | 更新 | 「こども」セクション(所属/未所属で分岐) |                                                                                                                                                    
  | `config/locales/activerecord/ja.yml` | 更新 | Child モデル名・属性名・エラー |                                                                                                                                                          
  | `config/locales/views/ja.yml` | 更新 | children / mypage の文言 |                                                                                                                                                                       
  | `app/views/shared/_footer.html.erb` | 更新 | ゲーム/楽しむアイコンを Material Icons `sports_esports` に変更 |                                                                                                                           
  | `app/views/dashboard/top.html.erb` | 更新 | 同上(face-smile 衝突回避) |                                                                                                                                                                 
                                                                                                                                                                                                                                            
  ## 実装のポイント                                                                                                                                                                                                                         
                                                                                                                                                                                                                                            
  ### データモデル                                                                                                 
  - **FamilyGroup -< Child** で、子は家族のものとして所有(User ではない)                                                                                                                                                                                  
                                                                                                                                                                                                                                            
  ### 認可(Pundit)                                                                                                                                                                                                                          
  - 家族グループの役割でCRUD認可: **メンバーは読める・オーナーだけが書ける**                                                                                                                                                                  
  - `Scope` は `pluck(:family_group_id)` を使い、将来「1ユーザー複数グループ」になっても壊れない書き方を採用                                                                                                                                
  - 親リソース(`FamilyGroup`)のメンバー検証はコントローラの `policy_scope(FamilyGroup).find_by!` に集約、Child Policy は「同一グループのオーナーか」のみを判定                                                                              
                                                                                                                                                                                                                                            
  ### ルーティング                                                                                                                                                                                                                          
  - `/family_groups/:family_group_uuid/children/:uuid` のネスト                                                                                                                                                                             
  - URL から所属グループが明示できるため、将来の複数グループ対応にも自然に拡張可能                                 
                                                                                                                                                                                                                                            
  ### UI
  - マイページに「こども」セクションを追加。**未所属ユーザーには「家族グループへの所属が必要」** と注意書きで自然な導線を作る                                                                 
  - アイコンは heroicons の `face-smile` で統一。同じアイコンを使っていた既存のゲーム/楽しむを Material Icons の `sports_esports` に置き換えて視覚的衝突を解消                                                                              
                                                                                                                          

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 家族グループ内での子ども情報管理機能を追加しました。子どもの登録、編集、削除が可能になり、氏名と誕生日を管理できます。
  * マイページに子どもセクションを追加し、登録した子ども一覧への簡単アクセスが可能になりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tantp-1111/mini_memory/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->