### PR TITLE
グループ削除が失敗する不具合を修正

### DIFF
--- a/app/models/user_family_group.rb
+++ b/app/models/user_family_group.rb
@@ -24,6 +24,8 @@ class UserFamilyGroup < ApplicationRecord
   end
 
   def ensure_at_least_one_owner_remains_after_leave
+    # 親 FamilyGroup の dependent: :destroy による削除時は、個別脱退用のガードを発火させない
+    return if destroyed_by_association
     return unless owner?
     return if other_owners_exist?
 


### PR DESCRIPTION
 ## 概要                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                            
  家族グループに **オーナーが 1 人しかいない場合**、グループの削除(解散)が失敗する不具合を修正。                                                                                                                                            
                                                                                                                                                                                                                                            
  ## 原因                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                            
  `UserFamilyGroup#ensure_at_least_one_owner_remains_after_leave` は **個別脱退** を防ぐための `before_destroy` ガードだが、親 `FamilyGroup` の `dependent: :destroy`                                                                       
  で削除されるケースでも発火し、最後のオーナーの所属レコードを消そうとした時点で `throw :abort` してグループ削除全体が中断していた。                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
  ## 修正内容                                                                                                                                                                                                                               
                                                                                                                    
  `belongs_to` が標準で提供する **`destroyed_by_association`** をチェックして、**親による destroy 時はガードをスキップ** するよう変更。                                                                                                     
                                                              
  ## 変更ファイル一覧                                                                                                                                                                                                                       
                                                                                                                    
  | ファイル | 種別 | 変更理由 |                               
  |---|---|---|
  | `app/models/user_family_group.rb` | 更新 | `before_destroy` ガードに `destroyed_by_association` チェックを追加 |   

  ## 動作確認
- [x] グループ削除ができる