### PR TITLE
投稿にこども選択機能を追加

### DIFF
--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -11,6 +11,7 @@ class MemoriesController < ApplicationController
   def new
     @memory = Memory.new
     authorize @memory
+    @available_children = policy_scope(Child).order(:birthday)
   end
 
   def create
@@ -26,18 +27,21 @@ class MemoriesController < ApplicationController
         flash[:success] = t("defaults.flash_message.created", model: Memory.model_name.human)
         redirect_to memories_path
       else
+        @available_children = policy_scope(Child).order(:birthday)
         flash.now[:error] = t("defaults.flash_message.not_created", model: Memory.model_name.human)
         render :new, status: :unprocessable_entity
       end
 
     # モジュールで設定したエラーのキャッチ
     rescue ImageProcessable::ImageProcessingError => e
+      @available_children = policy_scope(Child).order(:birthday)
       flash.now[:error] = e.message
       render :new, status: :unprocessable_entity
     end
   end
 
   def edit
+    @available_children = policy_scope(Child).order(:birthday)
   end
 
   def update
@@ -52,12 +56,14 @@ class MemoriesController < ApplicationController
         flash[:success] = t("defaults.flash_message.updated", model: Memory.model_name.human)
         redirect_to memories_path
       else
+        @available_children = policy_scope(Child).order(:birthday)
         flash.now[:error] = t("defaults.flash_message.not_updated", model: Memory.model_name.human)
         render :edit, status: :unprocessable_entity
       end
 
     # モジュールで設定したエラーのキャッチ
     rescue ImageProcessable::ImageProcessingError => e
+      @available_children = policy_scope(Child).order(:birthday)
       flash.now[:error] = e.message
       render :edit, status: :unprocessable_entity
     end
@@ -79,6 +85,9 @@ class MemoriesController < ApplicationController
   end
 
   def memory_params
-    params.require(:memory).permit(:title, :description, :memory_date, :visibility, :image)
+    params.require(:memory).permit(:title, :description, :memory_date, :visibility, :image, child_ids: []).tap do |whitelisted|
+      # 空文字列を除外
+      whitelisted[:child_ids]&.reject!(&:blank?)
+    end
   end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,3 +9,6 @@ application.register("hello", HelloController)
 
 import ClipboardController from "./clipboard_controller"
 application.register("clipboard", ClipboardController)
+
+import MemoryChildrenController from "./memory_children_controller"
+application.register("memory-children", MemoryChildrenController)

--- a/app/javascript/controllers/memory_children_controller.js
+++ b/app/javascript/controllers/memory_children_controller.js
@@ -14,7 +14,7 @@ export default class extends Controller {
   selectAll() {
     this.badgeTargets.forEach((badge) => {
       const childId = badge.dataset.childId
-      this.#select(badge, childId)
+      if (badge.dataset.selected !== "true") this.#select(badge, childId)
     })
   }
 
@@ -23,13 +23,15 @@ export default class extends Controller {
     badge.classList.remove("badge-outline")
     badge.dataset.selected = "true"
 
-    // input要素を動的に追加
-    const input = document.createElement("input")
-    input.type = "hidden"
-    input.name = "memory[child_ids][]"
-    input.value = childId
-    input.dataset.childId = childId
-    this.containerTarget.appendChild(input)
+    const existing = this.containerTarget.querySelector(`input[data-child-id="${childId}"]`)
+    if (!existing) {
+      const input = document.createElement("input")
+      input.type = "hidden"
+      input.name = "memory[child_ids][]"
+      input.value = childId
+      input.dataset.childId = childId
+      this.containerTarget.appendChild(input)
+    }
   }
 
   #deselect(badge, childId) {

--- a/app/javascript/controllers/memory_children_controller.js
+++ b/app/javascript/controllers/memory_children_controller.js
@@ -1,0 +1,44 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["badge", "container"]
+
+  toggle(event) {
+    const badge = event.currentTarget
+    const childId = badge.dataset.childId
+    const isSelected = badge.dataset.selected === "true"
+
+    isSelected ? this.#deselect(badge, childId) : this.#select(badge, childId)
+  }
+
+  selectAll() {
+    this.badgeTargets.forEach((badge) => {
+      const childId = badge.dataset.childId
+      this.#select(badge, childId)
+    })
+  }
+
+  #select(badge, childId) {
+    badge.classList.add("badge-primary")
+    badge.classList.remove("badge-outline")
+    badge.dataset.selected = "true"
+
+    // input要素を動的に追加
+    const input = document.createElement("input")
+    input.type = "hidden"
+    input.name = "memory[child_ids][]"
+    input.value = childId
+    input.dataset.childId = childId
+    this.containerTarget.appendChild(input)
+  }
+
+  #deselect(badge, childId) {
+    badge.classList.remove("badge-primary")
+    badge.classList.add("badge-outline")
+    badge.dataset.selected = "false"
+
+    // 該当するinput要素を削除
+    const input = this.containerTarget.querySelector(`input[data-child-id="${childId}"]`)
+    if (input) input.remove()
+  }
+}

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -1,5 +1,7 @@
 class Child < ApplicationRecord
   belongs_to :family_group
+  has_many :memory_children, dependent: :destroy
+  has_many :memories, through: :memory_children
 
   validates :name, presence: true, length: { maximum: 30 }
   validate :birthday_not_in_future, if: -> { birthday.present? }

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -9,10 +9,14 @@ class Memory < ApplicationRecord
   belongs_to :user
   has_one_attached :image
   has_many :reactions, dependent: :destroy
+  has_many :memory_children, dependent: :destroy
+  has_many :children, through: :memory_children
 
   # imageカスタムバリデーション
   validate :image_content_type
   validate :image_size
+  # 紐付け可能なこどもは投稿者の家族グループに属するものに限定
+  validate :children_must_belong_to_user_family_group
 
   # enum公開範囲定義
   enum :visibility, {
@@ -91,5 +95,17 @@ class Memory < ApplicationRecord
   # default画像表示用メソッド
   def default_image
     "memory_placeholder.png"
+  end
+
+  # 紐付け対象のこどもは投稿者の家族グループ内に限る（フォーム改ざん防御）
+  def children_must_belong_to_user_family_group
+    return if children.empty?
+    return if user.nil?
+
+    user_group_ids = user.user_family_groups.pluck(:family_group_id)
+    invalid = children.reject { |c| user_group_ids.include?(c.family_group_id) }
+    return if invalid.empty?
+
+    errors.add(:children, :not_in_user_family_group)
   end
 end

--- a/app/models/memory_child.rb
+++ b/app/models/memory_child.rb
@@ -1,0 +1,4 @@
+class MemoryChild < ApplicationRecord
+  belongs_to :memory
+  belongs_to :child
+end

--- a/app/views/memories/_child_selector.html.erb
+++ b/app/views/memories/_child_selector.html.erb
@@ -1,0 +1,41 @@
+<%# 投稿者の家族グループに属するこどもをバッジ形式で選択する UI %>
+<% if @available_children.present? %>
+  <div class="form-control gap-1" data-controller="memory-children">
+    <div class="flex items-center justify-between">
+      <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60">
+        <%= t("memories.form.children_label") %>
+      </span>
+      <button type="button"
+              data-action="click->memory-children#selectAll"
+              class="btn btn-ghost btn-xs">
+        <%= t("memories.form.select_all_children") %>
+      </button>
+    </div>
+
+    <div class="flex flex-wrap gap-2 pt-1">
+      <% @available_children.each do |child| %>
+        <% selected = @memory.children.include?(child) %>
+        <button type="button"
+                data-action="click->memory-children#toggle"
+                data-memory-children-target="badge"
+                data-child-id="<%= child.id %>"
+                data-selected="<%= selected %>"
+                class="badge badge-lg gap-1 cursor-pointer <%= selected ? 'badge-primary' : 'badge-outline' %>">
+          <%= child.name %>
+        </button>
+      <% end %>
+    </div>
+
+    <!-- hidden inputを格納するコンテナ -->
+    <div data-memory-children-target="container">
+      <%# 空配列を送信するための要素 %>
+      <input type="hidden" name="memory[child_ids][]" value="">
+      <% @memory.children.each do |child| %>
+        <input type="hidden"
+               name="memory[child_ids][]"
+               value="<%= child.id %>"
+               data-child-id="<%= child.id %>">
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/memories/edit.html.erb
+++ b/app/views/memories/edit.html.erb
@@ -88,6 +88,8 @@
             </div>
           </div>
 
+          <%= render "child_selector" %>
+
           <!-- 画像アップロード -->
           <div class="form-control gap-1">
             <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60"><%= t('helpers.label.image') %></span>

--- a/app/views/memories/new.html.erb
+++ b/app/views/memories/new.html.erb
@@ -88,6 +88,8 @@
             </div>
           </div>
 
+          <%= render "child_selector" %>
+
           <!-- 画像アップロード -->
           <div class="form-control gap-1">
             <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60"><%= t('helpers.label.image') %></span>

--- a/app/views/memories/show.html.erb
+++ b/app/views/memories/show.html.erb
@@ -53,6 +53,20 @@
         </span>
       </div>
 
+      <%# こども（掲示板/public_memories#show では描画されない） %>
+      <% if @memory.children.any? %>
+        <div>
+          <p class="text-xs font-bold tracking-widest text-base-content/40 mb-3">
+            <%= t('memories.show.children_label') %>
+          </p>
+          <div class="flex flex-wrap gap-2">
+            <% @memory.children.each do |child| %>
+              <span class="badge badge-primary badge-lg"><%= child.name %></span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+
       <%# エピソード %>
       <div>
         <p class="text-xs font-bold tracking-widest text-base-content/40 mb-3">

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -34,6 +34,10 @@ ja:
           attributes:
             birthday:
               in_future: は未来の日付を指定できません
+        memory:
+          attributes:
+            children:
+              not_in_user_family_group: には所属していない家族グループのこどもを指定できません
   enums:
     memory:
       visibility:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -74,6 +74,10 @@ ja:
       subtitle: 内容を編集できます
     show:
       return_to_list: 一覧に戻る
+      children_label: こども
+    form:
+      children_label: こども (任意)
+      select_all_children: 全員
   public_memories:
     index:
       title: 掲示板

--- a/db/migrate/20260522153523_create_memory_children.rb
+++ b/db/migrate/20260522153523_create_memory_children.rb
@@ -1,0 +1,10 @@
+class CreateMemoryChildren < ActiveRecord::Migration[7.2]
+  def change
+    create_table :memory_children do |t|
+      t.references :memory, null: false, foreign_key: true
+      t.references :child,  null: false, foreign_key: true
+      t.timestamps
+      t.index [ :memory_id, :child_id ], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_20_143244) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_22_153523) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -85,6 +85,16 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_20_143244) do
     t.index ["uuid"], name: "index_memories_on_uuid", unique: true
   end
 
+  create_table "memory_children", force: :cascade do |t|
+    t.bigint "memory_id", null: false
+    t.bigint "child_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["child_id"], name: "index_memory_children_on_child_id"
+    t.index ["memory_id", "child_id"], name: "index_memory_children_on_memory_id_and_child_id", unique: true
+    t.index ["memory_id"], name: "index_memory_children_on_memory_id"
+  end
+
   create_table "reactions", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "memory_id", null: false
@@ -128,6 +138,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_20_143244) do
   add_foreign_key "children", "family_groups"
   add_foreign_key "invitations", "family_groups"
   add_foreign_key "memories", "users"
+  add_foreign_key "memory_children", "children"
+  add_foreign_key "memory_children", "memories"
   add_foreign_key "reactions", "memories"
   add_foreign_key "reactions", "users"
   add_foreign_key "user_family_groups", "family_groups"


### PR DESCRIPTION
## 概要                                                                                                                                              
                                                                                                                                                       
 追加した Child を、Memory に **多対多** で紐付け可能にした。                                                                      
  投稿フォームでこどもをバッジ形式で複数選択でき、「全員」ボタンで一括選択も可能。                                                                     
  詳細画面では紐付いたこどもをバッジ表示するが、掲示板(public_memories#show)では非表示。  

- **未選択(0 件)も許可**: 既存メモリーを壊さない、こども未登録ユーザーも投稿可能                                  
- **任意の人数選択可**: 1 人でも 2 人でも複数可                                                                                                      
- **「全員」ボタンはスナップショット型**: 押下時点の Child を選択状態にする(後で子供が追加されても自動連動しない)   

## 変更ファイル一覧                                                                                                                                  
                                                                                                                                                       
  | ファイル | 種別 | 変更理由 |                                                                                                                       
  |---|---|---|                                                
  | `db/migrate/20260522153523_create_memory_children.rb` | 新規 | 中間テーブル(memory_id, child_id, 複合 unique index) |                              
  | `db/schema.rb` | 更新 | マイグレーション反映 |                                                                                                     
  | `app/models/memory_child.rb` | 新規 | 中間モデル |                                                                                                 
  | `app/models/memory.rb` | 更新 | `has_many :children, through: :memory_children`、家族グループ整合バリデーション |                                  
  | `app/models/child.rb` | 更新 | `has_many :memories, through: :memory_children` |                                                                   
  | `app/controllers/memories_controller.rb` | 更新 | `child_ids: []` 許可、空文字列除外、`@available_children` 取得 |
  | `app/views/memories/_child_selector.html.erb` | 新規 | バッジ + 「全員」ボタン + hidden input コンテナ |                                           
  | `app/views/memories/new.html.erb` | 更新 | `render "child_selector"` |                                                                             
  | `app/views/memories/edit.html.erb` | 更新 | `render "child_selector"` |                                                                            
  | `app/views/memories/show.html.erb` | 更新 | こどもバッジを投稿者下に表示 |                                                                         
  | `app/javascript/controllers/memory_children_controller.js` | 新規 | バッジクリック/全員ボタンで hidden input を動的生成・削除 |                    
  | `app/javascript/controllers/index.js` | 更新 | memory-children controller 登録 |                                                                   
  | `config/locales/activerecord/ja.yml` | 更新 | `not_in_user_family_group` エラー追加 |                           
  | `config/locales/views/ja.yml` | 更新 | form / show 文言を追加 |   

## 実装のポイント                                                                                                                                    
                                                                                                                                                       
  ### 多対多の選択                                                                                                                                     
  - 中間モデル方式(`has_many :through`)を採用。                                  
                                                                                                                                                       
  ### セキュリティ(二段防衛)                                                                                                                           
  - フォームに出すこども: `policy_scope(Child)` で自分の家族グループ内に限定                                                                           
  - 万一フォーム改ざんで他家族の child_id が送られても、モデル側 validation `children_must_belong_to_user_family_group` で弾く                         
                                                                                                                                                       
  ### 詳細画面と掲示板の出し分け                                                                                                                       
  - `memories/show.html.erb` のみバッジ描画                                                                                                            
  - `public_memories/show.html.erb` には描画コードを足さない → 掲示板閲覧者(不特定多数)にはこども情報が漏れない     
                                                                                                                                                       
  ## 動作確認                                                                                                                                                                                                                                                                                                             
  - [x] 編集時に追加・削除・全解除が正しく反映                 
  - [x] 「全員」ボタンで一括選択                                                                                                                       
  - [x] 家族グループ未所属 / こども未登録ユーザーで UI 非表示、投稿は可能                                                                                                             
  - [x] 詳細画面でバッジ表示、掲示板では非表示                                                                                                         
  - [x] 既存ミニメモリー(child 紐付けなし)が壊れていない                                

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * メモリの作成・編集時に子どもを選択・関連付けできるようになりました。
  * メモリ詳細ページに関連する子どもが表示されるようになりました。
  * 複数の子どもを一括選択できる「全て選択」ボタンが追加されました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tantp-1111/mini_memory/pull/238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->