### PR TITLE
 ミニメモリにタグ機能を追加

### DIFF
--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -85,7 +85,7 @@ class MemoriesController < ApplicationController
   end
 
   def memory_params
-    params.require(:memory).permit(:title, :description, :memory_date, :visibility, :image, child_ids: []).tap do |whitelisted|
+    params.require(:memory).permit(:title, :description, :memory_date, :visibility, :image, :tag_list_input, child_ids: []).tap do |whitelisted|
       # 空文字列を除外
       whitelisted[:child_ids]&.reject!(&:blank?)
     end

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -11,12 +11,23 @@ class Memory < ApplicationRecord
   has_many :reactions, dependent: :destroy
   has_many :memory_children, dependent: :destroy
   has_many :children, through: :memory_children
+  has_many :memory_tags, dependent: :destroy
+  has_many :tags, through: :memory_tags
 
   # imageカスタムバリデーション
   validate :image_content_type
   validate :image_size
   # 紐付け可能なこどもは投稿者の家族グループに属するものに限定
   validate :children_must_belong_to_user_family_group
+
+  # フォームのカンマ区切り入力を受け取るための仮想 attribute
+  attr_accessor :tag_list_input
+
+  # メモリーが保存された後に、tag_list_input をもとに tags 関連を同期する
+  after_save :sync_tags_from_input
+
+  TAG_LIMIT = 10
+  TAG_MAX_LENGTH = 30
 
   # enum公開範囲定義
   enum :visibility, {
@@ -107,5 +118,21 @@ class Memory < ApplicationRecord
     return if invalid.empty?
 
     errors.add(:children, :not_in_user_family_group)
+  end
+
+  # カンマ区切り入力をパースしてタグを同期する（after_save で呼ばれる）。
+  # - 前後 strip + 重複除外
+  # - 最大 TAG_LIMIT(10) 件まで採用
+  # - TAG_MAX_LENGTH(30) 字超のタグは静かに無視（投稿そのものを失敗させない）
+  def sync_tags_from_input
+    return unless @tag_list_input.is_a?(String)
+    return if user.nil?
+
+    names = @tag_list_input.split(",").map(&:strip).reject(&:blank?).uniq
+    names = names.first(TAG_LIMIT)
+    names = names.reject { |n| n.length > TAG_MAX_LENGTH }
+
+    new_tags = names.map { |name| user.tags.find_or_create_by!(name: name) }
+    self.tags = new_tags
   end
 end

--- a/app/models/memory_tag.rb
+++ b/app/models/memory_tag.rb
@@ -1,0 +1,4 @@
+class MemoryTag < ApplicationRecord
+  belongs_to :memory
+  belongs_to :tag
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,9 @@
+class Tag < ApplicationRecord
+  belongs_to :user
+  has_many :memory_tags, dependent: :destroy
+  has_many :memories, through: :memory_tags
+
+  validates :name, presence: true,
+                   length: { maximum: 30 },
+                   uniqueness: { scope: :user_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,7 @@ class User < ApplicationRecord
   has_many :user_family_groups, dependent: :destroy
   has_many :family_groups, through: :user_family_groups
   has_many :reactions, dependent: :destroy
+  has_many :tags, dependent: :destroy
 
   # バリデーション
   validates :name, presence: true

--- a/app/views/memories/_tag_input.html.erb
+++ b/app/views/memories/_tag_input.html.erb
@@ -5,8 +5,9 @@
       <%= t("memories.form.tag_list_label") %>
     </span>
   <% end %>
+  <%# バリデーション失敗時はユーザー入力(tag_list_input)を優先表示。通常時は DB の tags から組み立てる %>
   <%= f.text_field :tag_list_input,
-        value: f.object.tags.map(&:name).join(", "),
+        value: f.object.tag_list_input.presence || f.object.tags.map(&:name).join(", "),
         placeholder: t("memories.form.tag_list_placeholder"),
         class: "input input-bordered input-sm bg-base-200/50 focus:bg-base-100 focus:input-primary transition-all duration-200 w-full" %>
   <p class="text-xs text-base-content/50 mt-1"><%= t("memories.form.tag_list_hint") %></p>

--- a/app/views/memories/_tag_input.html.erb
+++ b/app/views/memories/_tag_input.html.erb
@@ -1,0 +1,13 @@
+<%# タグ入力フィールド（投稿/編集共通） %>
+<div class="form-control gap-1">
+  <%= f.label :tag_list_input, class: "label py-0" do %>
+    <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60">
+      <%= t("memories.form.tag_list_label") %>
+    </span>
+  <% end %>
+  <%= f.text_field :tag_list_input,
+        value: f.object.tags.map(&:name).join(", "),
+        placeholder: t("memories.form.tag_list_placeholder"),
+        class: "input input-bordered input-sm bg-base-200/50 focus:bg-base-100 focus:input-primary transition-all duration-200 w-full" %>
+  <p class="text-xs text-base-content/50 mt-1"><%= t("memories.form.tag_list_hint") %></p>
+</div>

--- a/app/views/memories/edit.html.erb
+++ b/app/views/memories/edit.html.erb
@@ -90,6 +90,8 @@
 
           <%= render "child_selector" %>
 
+          <%= render "tag_input", f: f %>
+
           <!-- 画像アップロード -->
           <div class="form-control gap-1">
             <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60"><%= t('helpers.label.image') %></span>

--- a/app/views/memories/new.html.erb
+++ b/app/views/memories/new.html.erb
@@ -90,6 +90,8 @@
 
           <%= render "child_selector" %>
 
+          <%= render "tag_input", f: f %>
+
           <!-- 画像アップロード -->
           <div class="form-control gap-1">
             <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60"><%= t('helpers.label.image') %></span>

--- a/app/views/memories/show.html.erb
+++ b/app/views/memories/show.html.erb
@@ -67,6 +67,20 @@
         </div>
       <% end %>
 
+      <%# タグ（こども同様、掲示板/public_memories#show では描画されない） %>
+      <% if @memory.tags.any? %>
+        <div>
+          <p class="text-xs font-bold tracking-widest text-base-content/40 mb-3">
+            <%= t('memories.show.tags_label') %>
+          </p>
+          <div class="flex flex-wrap gap-x-3 gap-y-1 text-sm text-secondary">
+            <% @memory.tags.each do |tag| %>
+              <span>#<%= tag.name %></span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+
       <%# エピソード %>
       <div>
         <p class="text-xs font-bold tracking-widest text-base-content/40 mb-3">

--- a/app/views/public_memories/show.html.erb
+++ b/app/views/public_memories/show.html.erb
@@ -53,6 +53,20 @@
         </span>
       </div>
 
+      <%# タグ %>
+      <% if @memory.tags.any? %>
+        <div>
+          <p class="text-xs font-bold tracking-widest text-base-content/40 mb-3">
+            <%= t('memories.show.tags_label') %>
+          </p>
+          <div class="flex flex-wrap gap-x-3 gap-y-1 text-sm text-secondary">
+            <% @memory.tags.each do |tag| %>
+              <span>#<%= tag.name %></span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+
       <%# エピソード %>
       <div>
         <p class="text-xs font-bold tracking-widest text-base-content/40 mb-3">

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -5,6 +5,7 @@ ja:
       memory: 思い出
       reaction: リアクション
       child: こども
+      tag: タグ
     attributes:
       user:
         email: メールアドレス
@@ -24,6 +25,8 @@ ja:
       child:
         name: 名前
         birthday: 生年月日
+      tag:
+        name: タグ名
     errors:
       models:
         reaction:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -75,9 +75,13 @@ ja:
     show:
       return_to_list: 一覧に戻る
       children_label: こども
+      tags_label: タグ
     form:
       children_label: こども (任意)
       select_all_children: 全員
+      tag_list_label: タグ (任意)
+      tag_list_placeholder: "例: 石, お花屋さん, 帰り道"
+      tag_list_hint: カンマ区切りで最大10個まで。30文字を超えるタグは反映されません
   public_memories:
     index:
       title: 掲示板

--- a/db/migrate/20260524073154_create_tags.rb
+++ b/db/migrate/20260524073154_create_tags.rb
@@ -1,0 +1,11 @@
+class CreateTags < ActiveRecord::Migration[7.2]
+  def change
+    create_table :tags do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :name, null: false
+      t.timestamps
+    end
+
+    add_index :tags, [ :user_id, :name ], unique: true
+  end
+end

--- a/db/migrate/20260524073155_create_memory_tags.rb
+++ b/db/migrate/20260524073155_create_memory_tags.rb
@@ -1,0 +1,11 @@
+class CreateMemoryTags < ActiveRecord::Migration[7.2]
+  def change
+    create_table :memory_tags do |t|
+      t.references :memory, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+      t.timestamps
+    end
+
+    add_index :memory_tags, [ :memory_id, :tag_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_22_153523) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_24_073155) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -95,6 +95,16 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_22_153523) do
     t.index ["memory_id"], name: "index_memory_children_on_memory_id"
   end
 
+  create_table "memory_tags", force: :cascade do |t|
+    t.bigint "memory_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["memory_id", "tag_id"], name: "index_memory_tags_on_memory_id_and_tag_id", unique: true
+    t.index ["memory_id"], name: "index_memory_tags_on_memory_id"
+    t.index ["tag_id"], name: "index_memory_tags_on_tag_id"
+  end
+
   create_table "reactions", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "memory_id", null: false
@@ -104,6 +114,15 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_22_153523) do
     t.index ["memory_id"], name: "index_reactions_on_memory_id"
     t.index ["user_id", "memory_id", "reaction_type"], name: "index_reactions_on_user_id_and_memory_id_and_reaction_type", unique: true
     t.index ["user_id"], name: "index_reactions_on_user_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "name"], name: "index_tags_on_user_id_and_name", unique: true
+    t.index ["user_id"], name: "index_tags_on_user_id"
   end
 
   create_table "user_family_groups", force: :cascade do |t|
@@ -140,8 +159,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_22_153523) do
   add_foreign_key "memories", "users"
   add_foreign_key "memory_children", "children"
   add_foreign_key "memory_children", "memories"
+  add_foreign_key "memory_tags", "memories"
+  add_foreign_key "memory_tags", "tags"
   add_foreign_key "reactions", "memories"
   add_foreign_key "reactions", "users"
+  add_foreign_key "tags", "users"
   add_foreign_key "user_family_groups", "family_groups"
   add_foreign_key "user_family_groups", "users"
 end


### PR DESCRIPTION
## 概要                                                                                                                                              
                                                                                                                                                                                                                  
  ユーザーが投稿/編集時にカンマ区切りでタグを入力でき、詳細画面と掲示板でハッシュタグ形式(#タグ名)で表示する。                                         

## データモデル

  - **タグはユーザー単位**(`tags.user_id`)、同名でもユーザーが違えば別レコード                                                                         
  - **多対多**(中間モデル `MemoryTag`)、Phase 2 のこども紐付けと同じ設計パターン
  - **未選択(0 個)も許可**: 任意指定、既存メモリーを壊さない  

## 変更ファイル一覧                                                                                                                                

  | ファイル | 種別 | 変更理由 |                                                                                                                       
  |---|---|---|
  | `db/migrate/20260524073154_create_tags.rb` | 新規 | tags テーブル(user_id, name, 複合 unique) |                                                    
  | `db/migrate/20260524073155_create_memory_tags.rb` | 新規 | 中間テーブル(memory_id, tag_id, 複合 unique) |                                          
  | `db/schema.rb` | 更新 | 上記マイグレーション反映 |                                                                                                 
  | `app/models/tag.rb` | 新規 | バリデーション(name 必須・30 字以内・user 内で uniq) |                                                                
  | `app/models/memory_tag.rb` | 新規 | 中間モデル |                                                                                                   
  | `app/models/memory.rb` | 更新 | `has_many :tags through:`、仮想 attribute `tag_list_input`、`after_save :sync_tags_from_input` |                   
  | `app/models/user.rb` | 更新 | `has_many :tags, dependent: :destroy` |                                                                              
  | `app/controllers/memories_controller.rb` | 更新 | `memory_params` に `:tag_list_input` を許可 |                                                    
  | `app/views/memories/_tag_input.html.erb` | 新規 | 投稿/編集共通のタグ入力パーシャル |                                                              
  | `app/views/memories/new.html.erb` | 更新 | `render "tag_input", f: f` |                                                                            
  | `app/views/memories/edit.html.erb` | 更新 | `render "tag_input", f: f` |                                                                           
  | `app/views/memories/show.html.erb` | 更新 | タグセクション(`#tag_name` 形式) |                                                                     
  | `app/views/public_memories/show.html.erb` | 更新 | タグセクション(同形式) |                                                                        
  | `config/locales/activerecord/ja.yml` | 更新 | Tag モデル名・属性名 |                                                                               
  | `config/locales/views/ja.yml` | 更新 | フォーム文言・show ラベル |     

## 実装のポイント                                                                                                                                    
                                                                                                                                                     
  ### 入力 → 同期フロー                                                                                                                                
  - フォームは仮想 attribute `tag_list_input` で文字列を受け取る                                                                                     
  - `after_save :sync_tags_from_input` で memory が確実に保存された後にタグを同期                                                                      
    → 保存失敗時に不完全なタグが生まれるのを防止するため                                                                                                           
  - 内部処理: `split(",") → strip → reject(blank) → uniq → first(10) → reject(30字超)`                                                                 
  - `user.tags.find_or_create_by!(name:)` で既存タグを再利用、なければ作成                                                                             
  - `self.tags = new_tags` で Rails が差分で `memory_tags` を INSERT/DELETE                                                                            
                                                                                                                                                       
  ### 全消去への対応                                                                                                                                   
  - タグ欄を空文字で送信すると `@tag_list_input == ""` で `split → []` になり、`memory.tags = []` でタグが全消去される                                 
  - 編集時に「全タグを外す」が正しく動作                                                                                                               
                                                                                                                                                       
  ### タグ数の上限                                                                                                                                    
  - **1 メモリーあたり最大 10 個**: 11 個目以降は切り捨て                                                                                        
  - **30 文字超のタグは無視**: バリデーションエラーにせず投稿は成功させる UX                                                                           
    → 主機能(メモリー投稿)を阻害しない                                                                                                                 
  - View にヒント文「カンマ区切りで最大10個まで。30文字を超えるタグは反映されません」で明示                                                            
                                                                                                                                                       
  ### 重複対策(二段防衛)                                                                                                                               
  - モデル側: `uniqueness: { scope: :user_id }` + 入力の `uniq`                                                                                        
  - DB 側: `[user_id, name]` の複合 unique index                                                                                                       
  - 並行リクエストでの race condition は最終的に DB 制約で弾く                                                                                         
                                                                                                                                                       
  ### 表示方針                                                                                                                                         
  - ハッシュタグ形式 `#石 #お花屋さん #帰り道`(バッジではなく横並びテキスト)                                                                           
  - 色は `text-secondary`(こどもの `badge-primary` と区別)                                                                                             
  - **タグは分類情報** → 掲示板でも公開可能                                                                                                            
  - **こどもは個人特定情報** → 掲示板では引き続き非表示(Phase 2 から維持)                                                                              
                                                                                                                                                       
  ### Pundit 認可                                                                                                                                      
  - Tag は Memory の仮想 attribute 経由でしか操作されないため `TagPolicy` 不要                                                                         
  - フォーム側で他人のタグを参照することがない設計                                                                                                     
                                                                                                                                                       
  ## テスト計画                                                                                                                                        
                                                                                                                                                       
  - [x] 投稿時に未指定 / 1 個 / 複数指定でタグが正しく中間テーブルに INSERT                                                                            
  - [x] 編集時に追加・削除・全消去が反映                                                                                                             
  - [x] カンマ区切り入力の strip / 重複除外 / 11 個目以降の切り捨て                                                                                    
  - [x] 30 字超のタグが静かに無視され、他のタグは正常登録                                                                                              
  - [x] 同名タグの再利用(同じユーザーが「石」を 2 投稿で使う → tags テーブルは 1 行)                                                                   
  - [x] 別ユーザーが同名タグを使う → 別レコードとして共存                                                                                              
  - [x] `memories#show` でハッシュタグ表示                                                                                                             
  - [x] `public_memories#show` でハッシュタグ表示(こどもは非表示のまま)                                                                                
  - [x] 既存ミニメモリー(タグなし)が壊れない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * メモにタグ機能を追加しました。メモの作成・編集時にタグを入力でき、最大10個までタグをつけることができます。タグはカンマ区切りで入力し、各タグは最大30文字まで対応しています。メモの詳細ページと公開ページでタグが表示されるようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tantp-1111/mini_memory/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->