### PR TITLE
バリデーション失敗時にミニメモリの添付画像を保持するよう修正

### DIFF
--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -19,9 +19,10 @@ class MemoriesController < ApplicationController
     authorize @memory
 
     begin
-      if params[:memory][:image].present?
-        @memory.image = ImageProcessable.process_and_transform_image(params[:memory][:image], 854)
-      end
+      # multipart で生ファイルが送られた場合のみ webp 変換 + attach し直す。
+      # direct_upload や hidden_field 経由で signed_id 文字列が来た場合は、
+      # build(memory_params) の時点で既に attach 済みなので追加処理は不要。
+      attach_processed_image!(@memory) if params[:memory][:image].is_a?(ActionDispatch::Http::UploadedFile)
 
       if @memory.save
         flash[:success] = t("defaults.flash_message.created", model: Memory.model_name.human)
@@ -47,9 +48,14 @@ class MemoriesController < ApplicationController
   def update
     begin
       @memory.assign_attributes(memory_params.except(:image))
-      # 画像がアップロードされている場合のみ画像処理を実行
-      if params[:memory][:image].present?
-        @memory.image = ImageProcessable.process_and_transform_image(params[:memory][:image], 854)
+      # multipart で生ファイルが送られた場合のみ webp 変換 + attach し直す。
+      # direct_upload や hidden_field 経由で signed_id 文字列が来た場合は、
+      # assign_attributes 側ですでに attach 済みのため追加処理は不要。
+      if params[:memory][:image].is_a?(ActionDispatch::Http::UploadedFile)
+        attach_processed_image!(@memory)
+      elsif params[:memory][:image].is_a?(String) && params[:memory][:image].present?
+        # signed_id 文字列を memory に attach(assign_attributes は image を except していたため)
+        @memory.image = params[:memory][:image]
       end
 
       if @memory.save
@@ -89,5 +95,18 @@ class MemoriesController < ApplicationController
       # 空文字列を除外
       whitelisted[:child_ids]&.reject!(&:blank?)
     end
+  end
+
+  # webp 変換した画像を blob として即時アップロードして memory に attach する。
+  # blob を即 persist + storage upload しておくことで、バリデーション失敗で
+  # render :new/:edit になった場合もプレビューが再表示できる。
+  def attach_processed_image!(memory)
+    processed = ImageProcessable.process_and_transform_image(params[:memory][:image], 854)
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: processed.tempfile,
+      filename: processed.original_filename,
+      content_type: processed.content_type
+    )
+    memory.image.attach(blob)
   end
 end

--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -100,6 +100,9 @@ class MemoriesController < ApplicationController
   # webp 変換した画像を blob として即時アップロードして memory に attach する。
   # blob を即 persist + storage upload しておくことで、バリデーション失敗で
   # render :new/:edit になった場合もプレビューが再表示できる。
+  #
+  # ActiveStorage の create_and_upload! が投げる例外は ImageProcessable::ImageProcessingError
+  # にラップして、create/update 側の rescue に接続する。
   def attach_processed_image!(memory)
     processed = ImageProcessable.process_and_transform_image(params[:memory][:image], 854)
     blob = ActiveStorage::Blob.create_and_upload!(
@@ -108,5 +111,8 @@ class MemoriesController < ApplicationController
       content_type: processed.content_type
     )
     memory.image.attach(blob)
+  rescue ActiveStorage::Error, ActiveRecord::RecordInvalid => e
+    Rails.logger.error "Image upload error: #{e.message}"
+    raise ImageProcessable::ImageProcessingError, "画像の保存中にエラーが発生しました: #{e.message}"
   end
 end

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -1,13 +1,26 @@
+// 直近で生成した object URL を保持し、不要になったタイミングで revoke してメモリリークを防ぐ
+let currentObjectUrl = null;
+
+function revokeCurrentObjectUrl() {
+    if (currentObjectUrl) {
+        URL.revokeObjectURL(currentObjectUrl);
+        currentObjectUrl = null;
+    }
+}
+
 // 画像プレビューを生成して new-image コンテナに差し替える
 function renderPreview(file) {
     const imageContainer = document.getElementById('new-image');
     if (!imageContainer) return;
 
-    // 既存の img (ERB 描画/JS 追加) を全て削除して入れ替える
+    // 既存 img (ERB 描画/JS 追加) を全て削除し、前回の object URL を解放する
     imageContainer.innerHTML = '';
+    revokeCurrentObjectUrl();
+
+    currentObjectUrl = window.URL.createObjectURL(file);
 
     const blobImage = document.createElement('img');
-    blobImage.src = window.URL.createObjectURL(file);
+    blobImage.src = currentObjectUrl;
     blobImage.dataset.jsPreview = 'true'; // JS で動的に追加した preview を識別するマーク
     blobImage.classList.add('h-full', 'w-auto', 'block', 'mx-auto', 'mt-2');
     imageContainer.appendChild(blobImage);
@@ -31,7 +44,10 @@ document.addEventListener('change', (e) => {
 
 // バックボタンキャッシュの clean up
 // ERB が描画した既存画像は残し、JS で追加した preview のみクリアする
+// 残っている object URL もここで revoke する
 document.addEventListener('turbo:before-cache', () => {
+    revokeCurrentObjectUrl();
+
     const previews = document.getElementById('new-image');
     if (previews) {
         previews.querySelectorAll('img[data-js-preview]').forEach((el) => el.remove());

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -1,45 +1,44 @@
-document.addEventListener('turbo:load', () => {
-    if (document.URL.match(/\/memories\/new/) || document.URL.match(/\/memories\/\d+\/edit/)) {
+// 画像プレビューを生成して new-image コンテナに差し替える
+function renderPreview(file) {
+    const imageContainer = document.getElementById('new-image');
+    if (!imageContainer) return;
 
-            const imageContainer = document.getElementById('new-image');
-            const imageInput = document.getElementById('memory_image');
+    // 既存の img (ERB 描画/JS 追加) を全て削除して入れ替える
+    imageContainer.innerHTML = '';
 
-            // 要素が存在しない場合は処理を中断
-            if (!imageContainer || !imageInput) return;
+    const blobImage = document.createElement('img');
+    blobImage.src = window.URL.createObjectURL(file);
+    blobImage.dataset.jsPreview = 'true'; // JS で動的に追加した preview を識別するマーク
+    blobImage.classList.add('h-full', 'w-auto', 'block', 'mx-auto', 'mt-2');
+    imageContainer.appendChild(blobImage);
 
-            // 画像表示用の関数
-            const createImageHTML = (blob) => {
-                // const imageElement = document.getElementById('new-image'); //ビューで指定したnew-imageのdiv要素を代入
-                const blobImage = document.createElement('img'); //img要素を作成
-                blobImage.setAttribute('src', blob); //imgのsrc属性にblob
-                blobImage.classList.add('h-full', 'w-auto', 'block', 'mx-auto', 'mt-2'); //画像のスタイル調整（Tailwind CSS）
-                imageContainer.appendChild(blobImage); //div要素にimg要素
-            };
-
-            // 画像が選択されたときのイベント
-            imageInput.addEventListener('change', (e) =>{
-                imageContainer.innerHTML = ""; //画像を一旦クリアする
-                const file = e.target.files[0]; //フォームで選択したファイルを取得
-                const blob =window.URL.createObjectURL(file); //選択したファイルのURLを取得
-                createImageHTML(blob); //画像表示用の関数を実行
-                // ▼ ファイル名を表示するエリアを取得して、ファイル名をセットして表示
-                const fileNameEl = document.getElementById('file-name');
-                if (fileNameEl) {
-                    fileNameEl.textContent = file.name;
-                    fileNameEl.classList.remove('hidden');
-                }
-            });
-
+    const fileNameEl = document.getElementById('file-name');
+    if (fileNameEl) {
+        fileNameEl.textContent = file.name;
+        fileNameEl.classList.remove('hidden');
     }
+}
+
+// document レベルで delegation することで、Turbo が body を置き換えた後でも
+// 新しい input 要素に対して同じハンドラが有効に動く
+// (turbo:load 内での addEventListener では再レンダリング後の要素を拾えないため)
+document.addEventListener('change', (e) => {
+    if (e.target.id !== 'memory_image') return;
+    const file = e.target.files[0];
+    if (!file) return;
+    renderPreview(file);
 });
 
-            // キャッシュ削除
-            document.addEventListener('turbo:before-cache', () => {
-                const previews = document.getElementById('new-image');
-                if (previews) previews.innerHTML = "";
-                const fileNameEl = document.getElementById('file-name');
-                if (fileNameEl) {
-                    fileNameEl.textContent = "";
-                    fileNameEl.classList.add('hidden');
-                }
-            });
+// バックボタンキャッシュの clean up
+// ERB が描画した既存画像は残し、JS で追加した preview のみクリアする
+document.addEventListener('turbo:before-cache', () => {
+    const previews = document.getElementById('new-image');
+    if (previews) {
+        previews.querySelectorAll('img[data-js-preview]').forEach((el) => el.remove());
+    }
+    const fileNameEl = document.getElementById('file-name');
+    if (fileNameEl) {
+        fileNameEl.textContent = '';
+        fileNameEl.classList.add('hidden');
+    }
+});

--- a/app/views/memories/edit.html.erb
+++ b/app/views/memories/edit.html.erb
@@ -124,6 +124,9 @@
               <!-- ファイル名表示（新規選択時） -->
               <p id="file-name" class="hidden text-xs text-base-content/50 text-center truncate px-2"></p>
 
+              <%# バリデーション失敗時に新規選択画像(in-memory attachment) を保持。
+                  id は file_field と衝突させないため別名にする(label[for] が hidden を拾うのを防ぐ) %>
+              <%= f.hidden_field :image, value: @memory.image.signed_id, id: "memory_image_signed_id" if @memory.image.attached? && @memory.image.blob&.persisted? %>
               <%= f.file_field :image,
                     id: "memory_image",
                     direct_upload: true,

--- a/app/views/memories/new.html.erb
+++ b/app/views/memories/new.html.erb
@@ -113,10 +113,20 @@
               </div>
 
               <%# ▼ プレビュー エリア ▼ %>
-              <div id="new-image" class="w-full rounded-lg overflow-hidden empty:hidden [&:not(:empty)]:h-32"></div>
+              <%# new では @memory が未保存のため display_image(variant) は signed_id 取得で失敗する %>
+              <%# blob から直接 URL を取り、ブラウザ側でプレビューさせる %>
+              <div id="new-image" class="w-full rounded-lg overflow-hidden empty:hidden [&:not(:empty)]:h-32">
+                <% if @memory.image.attached? && @memory.image.blob&.persisted? %>
+                  <%= image_tag rails_blob_url(@memory.image.blob, only_path: true), class: "h-full mx-auto object-cover" %>
+                <% end %>
+              </div>
               <%# ▼ ファイル名表示エリア ▼ %>
                 <p id="file-name" class="hidden text-xs text-base-content/50 text-center truncate px-2"></p>
 
+              <%# バリデーション失敗時に既存 attachment を保持(blob は事前に永続化済み)。
+                  HTML順で hidden→file_field の順なので、新ファイル選択時は direct_upload の値が後勝ち。
+                  id は file_field と衝突させないため別名にする(label[for] が hidden を拾うのを防ぐ) %>
+              <%= f.hidden_field :image, value: @memory.image.signed_id, id: "memory_image_signed_id" if @memory.image.attached? && @memory.image.blob&.persisted? %>
               <%= f.file_field :image,
                     id: "memory_image",
                     direct_upload: true,


### PR DESCRIPTION
## 概要                                                                                                                                              
                                                                                                                                                       
  ミニメモリの新規投稿/編集でバリデーション失敗(タイトル空欄など)になり `render :new/:edit`                                                            
  で再表示される際、ユーザーが添付した画像が消えてしまう不具合を修正。

 ## 修正内容                                                                                                                                          
                                                                                                                    
  ### 1. view: signed_id を hidden で保持                    
                                                                                                                                                       
  ```erb
  <%= f.hidden_field :image, value: @memory.image.signed_id,                                                                                           
        id: "memory_image_signed_id"                                                                                
        if @memory.image.attached? && @memory.image.blob&.persisted? %>                                                                                
  <%= f.file_field :image, id: "memory_image", direct_upload: true, ... %>
  ```                                                                                                                                                  
                                                                                                                    
  - file 未選択時は hidden の signed_id が送信                                                                        
  ### 2. controller: blob を即 persist                                                                                                                 
                                                                                                                                                       
  ```ruby                                                                                                                                              
  def attach_processed_image!(memory)                                                                               
    processed = ImageProcessable.process_and_transform_image(params[:memory][:image], 854)
    blob = ActiveStorage::Blob.create_and_upload!(                                                                                                     
      io: processed.tempfile,
      filename: processed.original_filename,                                                                                                           
      content_type: processed.content_type                                                                          
    )                                                                                                                                                  
    memory.image.attach(blob)                                                                                       
  end                                                        
  ```

  `ActiveStorage::Blob.create_and_upload!` で **blob 作成 + storage upload を即時に実行**。バリデーション失敗で memory.save が走らなくても blob は DB  と storage に残るので、view 側でプレビュー可能になる。
                                                                                                                                                       
  ### 3. controller: signed_id 文字列とファイルを分岐                                                                                                  
                                                             
  ```ruby                                                                                                                                              
  if params[:memory][:image].is_a?(ActionDispatch::Http::UploadedFile)                                              
    attach_processed_image!(@memory)                                                                                                                   
  end                                                                                                                                                  
  ```                                                                                                                                                  
                                                                                                                                                       
  direct_upload や hidden 経由の **signed_id 文字列** は `build(memory_params)` の時点で既に attach されているため、`ImageProcessable`を呼ばない。文字列を `ImageProcessing::Vips.source` に渡すと `VipsForeignLoad: file does not exist` で 500 になっていたのを防ぐ。                    
   
  ### 4. preview.js: event delegation                                                                                                                  
                                                                                                                    
  ```javascript                                              
  document.addEventListener('change', (e) => {
    if (e.target.id !== 'memory_image') return;
    // プレビュー更新                                                                                                                                  
  });
  ```                                                                                                                                                  
                                                                                                                    
  `turbo:load` 内ではなく `document` レベルで `change` イベントを delegate することで、Turbo が body を置き換えた後の新しい file_fieldでも常に動作する。                                                                                                                                   
   
  ## new と memory.image.signed_id について                                                                                                            
                                                                                                                    
  未保存 Memory の attached one でも `signed_id` を呼べるのは、内部で **blob.signed_id** に委譲されているため。blob が persisted なら(本 PR では `create_and_upload!` で即 persist しているので必ず true)、memory が new record でも signed_id 取得可能。 


  ## 変更ファイル一覧

  | ファイル | 種別 | 変更理由 |
  |---|---|---|                                                                                                                                        
  | `app/controllers/memories_controller.rb` | 更新 | `attach_processed_image!` ヘルパー追加、`UploadedFile` 判定で `ImageProcessable` 呼び出しを分岐、`Blob.create_and_upload!` で即 persist |                                                                                             
  | `app/views/memories/new.html.erb` | 更新 | `hidden_field :image`(別 id) + blob URL でプレビュー描画 |           
  | `app/views/memories/edit.html.erb` | 更新 | `hidden_field :image`(別 id) |                                                                         
  | `app/javascript/preview.js` | 更新 | event delegation 方式に書き換え |                                          
                                                                                                                                                       
  ## テスト計画                                                                                                     
                                                                                                                                                       
  - [x] 新規: タイトル空欄 + 画像添付 → エラー画面でプレビュー残る → タイトル入力して再送信成功                     
  - [x] 新規: 画像再選択 → プレビューが新しい画像に切り替わる                                                                                          
  - [x] 編集: 画像差し替え + タイトル空欄 → エラー画面で新画像プレビュー → 再送信で更新成功                                                            
  - [x] 通常の新規投稿(全項目埋め) → 投稿成功                                                                                                          
  - [x] バックボタンで戻った時にプレビューが不自然に残らない      

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 画像アップロードのプレビュー表示が改善されました
  * バリデーションエラー時に選択した画像が正しく保持されるようになりました
  * ページ遷移後も画像選択状態が適切に保持されるようになりました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tantp-1111/mini_memory/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->