### PR TITLE
[Release] こども管理・タグ機能・バグ修正

### DIFF
--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -1,0 +1,64 @@
+class ChildrenController < ApplicationController
+  before_action :set_family_group
+  before_action :set_child, only: %i[edit update destroy]
+
+  def index
+    @children = policy_scope(@family_group.children).order(:birthday)
+    authorize @family_group, :show?
+  end
+
+  def new
+    @child = @family_group.children.new
+    authorize @child
+  end
+
+  def create
+    @child = @family_group.children.new(child_params)
+    authorize @child
+
+    if @child.save
+      redirect_to family_group_children_path(@family_group),
+                  notice: t("defaults.flash_message.created", model: Child.model_name.human)
+    else
+      flash.now[:alert] = t("defaults.flash_message.not_created", model: Child.model_name.human)
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    authorize @child
+  end
+
+  def update
+    authorize @child
+    if @child.update(child_params)
+      redirect_to family_group_children_path(@family_group),
+                  notice: t("defaults.flash_message.updated", model: Child.model_name.human)
+    else
+      flash.now[:alert] = t("defaults.flash_message.not_updated", model: Child.model_name.human)
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    authorize @child
+    @child.destroy!
+    redirect_to family_group_children_path(@family_group),
+                notice: t("defaults.flash_message.deleted", model: Child.model_name.human)
+  end
+
+  private
+
+  # 非メンバーには 404（存在を隠す）、メンバー以上には authorize で操作種別を判定する二段防衛。
+  def set_family_group
+    @family_group = policy_scope(FamilyGroup).find_by!(uuid: params[:family_group_uuid])
+  end
+
+  def set_child
+    @child = @family_group.children.find_by!(uuid: params[:uuid])
+  end
+
+  def child_params
+    params.require(:child).permit(:name, :birthday)
+  end
+end

--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -19,9 +19,10 @@ class MemoriesController < ApplicationController
     authorize @memory
 
     begin
-      if params[:memory][:image].present?
-        @memory.image = ImageProcessable.process_and_transform_image(params[:memory][:image], 854)
-      end
+      # multipart で生ファイルが送られた場合のみ webp 変換 + attach し直す。
+      # direct_upload や hidden_field 経由で signed_id 文字列が来た場合は、
+      # build(memory_params) の時点で既に attach 済みなので追加処理は不要。
+      attach_processed_image!(@memory) if params[:memory][:image].is_a?(ActionDispatch::Http::UploadedFile)
 
       if @memory.save
         flash[:success] = t("defaults.flash_message.created", model: Memory.model_name.human)
@@ -47,9 +48,14 @@ class MemoriesController < ApplicationController
   def update
     begin
       @memory.assign_attributes(memory_params.except(:image))
-      # 画像がアップロードされている場合のみ画像処理を実行
-      if params[:memory][:image].present?
-        @memory.image = ImageProcessable.process_and_transform_image(params[:memory][:image], 854)
+      # multipart で生ファイルが送られた場合のみ webp 変換 + attach し直す。
+      # direct_upload や hidden_field 経由で signed_id 文字列が来た場合は、
+      # assign_attributes 側ですでに attach 済みのため追加処理は不要。
+      if params[:memory][:image].is_a?(ActionDispatch::Http::UploadedFile)
+        attach_processed_image!(@memory)
+      elsif params[:memory][:image].is_a?(String) && params[:memory][:image].present?
+        # signed_id 文字列を memory に attach(assign_attributes は image を except していたため)
+        @memory.image = params[:memory][:image]
       end
 
       if @memory.save
@@ -89,5 +95,18 @@ class MemoriesController < ApplicationController
       # 空文字列を除外
       whitelisted[:child_ids]&.reject!(&:blank?)
     end
+  end
+
+  # webp 変換した画像を blob として即時アップロードして memory に attach する。
+  # blob を即 persist + storage upload しておくことで、バリデーション失敗で
+  # render :new/:edit になった場合もプレビューが再表示できる。
+  def attach_processed_image!(memory)
+    processed = ImageProcessable.process_and_transform_image(params[:memory][:image], 854)
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: processed.tempfile,
+      filename: processed.original_filename,
+      content_type: processed.content_type
+    )
+    memory.image.attach(blob)
   end
 end

--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -100,6 +100,9 @@ class MemoriesController < ApplicationController
   # webp 変換した画像を blob として即時アップロードして memory に attach する。
   # blob を即 persist + storage upload しておくことで、バリデーション失敗で
   # render :new/:edit になった場合もプレビューが再表示できる。
+  #
+  # ActiveStorage の create_and_upload! が投げる例外は ImageProcessable::ImageProcessingError
+  # にラップして、create/update 側の rescue に接続する。
   def attach_processed_image!(memory)
     processed = ImageProcessable.process_and_transform_image(params[:memory][:image], 854)
     blob = ActiveStorage::Blob.create_and_upload!(
@@ -108,5 +111,8 @@ class MemoriesController < ApplicationController
       content_type: processed.content_type
     )
     memory.image.attach(blob)
+  rescue ActiveStorage::Error, ActiveRecord::RecordInvalid => e
+    Rails.logger.error "Image upload error: #{e.message}"
+    raise ImageProcessable::ImageProcessingError, "画像の保存中にエラーが発生しました: #{e.message}"
   end
 end

--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -11,6 +11,7 @@ class MemoriesController < ApplicationController
   def new
     @memory = Memory.new
     authorize @memory
+    @available_children = policy_scope(Child).order(:birthday)
   end
 
   def create
@@ -26,18 +27,21 @@ class MemoriesController < ApplicationController
         flash[:success] = t("defaults.flash_message.created", model: Memory.model_name.human)
         redirect_to memories_path
       else
+        @available_children = policy_scope(Child).order(:birthday)
         flash.now[:error] = t("defaults.flash_message.not_created", model: Memory.model_name.human)
         render :new, status: :unprocessable_entity
       end
 
     # モジュールで設定したエラーのキャッチ
     rescue ImageProcessable::ImageProcessingError => e
+      @available_children = policy_scope(Child).order(:birthday)
       flash.now[:error] = e.message
       render :new, status: :unprocessable_entity
     end
   end
 
   def edit
+    @available_children = policy_scope(Child).order(:birthday)
   end
 
   def update
@@ -52,12 +56,14 @@ class MemoriesController < ApplicationController
         flash[:success] = t("defaults.flash_message.updated", model: Memory.model_name.human)
         redirect_to memories_path
       else
+        @available_children = policy_scope(Child).order(:birthday)
         flash.now[:error] = t("defaults.flash_message.not_updated", model: Memory.model_name.human)
         render :edit, status: :unprocessable_entity
       end
 
     # モジュールで設定したエラーのキャッチ
     rescue ImageProcessable::ImageProcessingError => e
+      @available_children = policy_scope(Child).order(:birthday)
       flash.now[:error] = e.message
       render :edit, status: :unprocessable_entity
     end
@@ -79,6 +85,9 @@ class MemoriesController < ApplicationController
   end
 
   def memory_params
-    params.require(:memory).permit(:title, :description, :memory_date, :visibility, :image)
+    params.require(:memory).permit(:title, :description, :memory_date, :visibility, :image, child_ids: []).tap do |whitelisted|
+      # 空文字列を除外
+      whitelisted[:child_ids]&.reject!(&:blank?)
+    end
   end
 end

--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -85,7 +85,7 @@ class MemoriesController < ApplicationController
   end
 
   def memory_params
-    params.require(:memory).permit(:title, :description, :memory_date, :visibility, :image, child_ids: []).tap do |whitelisted|
+    params.require(:memory).permit(:title, :description, :memory_date, :visibility, :image, :tag_list_input, child_ids: []).tap do |whitelisted|
       # 空文字列を除外
       whitelisted[:child_ids]&.reject!(&:blank?)
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,7 +38,9 @@ module ApplicationHelper
   end
 
   def ogp_image_url
-    if @memory&.image&.attached?
+    # @memory が未保存(new record)だと signed_id を取得できないため persisted? を必須にする。
+    # 例: 投稿バリデーション失敗で render :new された場合、画像 attach 済みでも未保存
+    if @memory&.persisted? && @memory.image.attached?
       return rails_blob_url(@memory.image, only_path: false)
     end
     image_url("minimemory_ogp.png")

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,3 +9,6 @@ application.register("hello", HelloController)
 
 import ClipboardController from "./clipboard_controller"
 application.register("clipboard", ClipboardController)
+
+import MemoryChildrenController from "./memory_children_controller"
+application.register("memory-children", MemoryChildrenController)

--- a/app/javascript/controllers/memory_children_controller.js
+++ b/app/javascript/controllers/memory_children_controller.js
@@ -14,7 +14,7 @@ export default class extends Controller {
   selectAll() {
     this.badgeTargets.forEach((badge) => {
       const childId = badge.dataset.childId
-      this.#select(badge, childId)
+      if (badge.dataset.selected !== "true") this.#select(badge, childId)
     })
   }
 
@@ -23,13 +23,15 @@ export default class extends Controller {
     badge.classList.remove("badge-outline")
     badge.dataset.selected = "true"
 
-    // input要素を動的に追加
-    const input = document.createElement("input")
-    input.type = "hidden"
-    input.name = "memory[child_ids][]"
-    input.value = childId
-    input.dataset.childId = childId
-    this.containerTarget.appendChild(input)
+    const existing = this.containerTarget.querySelector(`input[data-child-id="${childId}"]`)
+    if (!existing) {
+      const input = document.createElement("input")
+      input.type = "hidden"
+      input.name = "memory[child_ids][]"
+      input.value = childId
+      input.dataset.childId = childId
+      this.containerTarget.appendChild(input)
+    }
   }
 
   #deselect(badge, childId) {

--- a/app/javascript/controllers/memory_children_controller.js
+++ b/app/javascript/controllers/memory_children_controller.js
@@ -1,0 +1,44 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["badge", "container"]
+
+  toggle(event) {
+    const badge = event.currentTarget
+    const childId = badge.dataset.childId
+    const isSelected = badge.dataset.selected === "true"
+
+    isSelected ? this.#deselect(badge, childId) : this.#select(badge, childId)
+  }
+
+  selectAll() {
+    this.badgeTargets.forEach((badge) => {
+      const childId = badge.dataset.childId
+      this.#select(badge, childId)
+    })
+  }
+
+  #select(badge, childId) {
+    badge.classList.add("badge-primary")
+    badge.classList.remove("badge-outline")
+    badge.dataset.selected = "true"
+
+    // input要素を動的に追加
+    const input = document.createElement("input")
+    input.type = "hidden"
+    input.name = "memory[child_ids][]"
+    input.value = childId
+    input.dataset.childId = childId
+    this.containerTarget.appendChild(input)
+  }
+
+  #deselect(badge, childId) {
+    badge.classList.remove("badge-primary")
+    badge.classList.add("badge-outline")
+    badge.dataset.selected = "false"
+
+    // 該当するinput要素を削除
+    const input = this.containerTarget.querySelector(`input[data-child-id="${childId}"]`)
+    if (input) input.remove()
+  }
+}

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -1,13 +1,26 @@
+// 直近で生成した object URL を保持し、不要になったタイミングで revoke してメモリリークを防ぐ
+let currentObjectUrl = null;
+
+function revokeCurrentObjectUrl() {
+    if (currentObjectUrl) {
+        URL.revokeObjectURL(currentObjectUrl);
+        currentObjectUrl = null;
+    }
+}
+
 // 画像プレビューを生成して new-image コンテナに差し替える
 function renderPreview(file) {
     const imageContainer = document.getElementById('new-image');
     if (!imageContainer) return;
 
-    // 既存の img (ERB 描画/JS 追加) を全て削除して入れ替える
+    // 既存 img (ERB 描画/JS 追加) を全て削除し、前回の object URL を解放する
     imageContainer.innerHTML = '';
+    revokeCurrentObjectUrl();
+
+    currentObjectUrl = window.URL.createObjectURL(file);
 
     const blobImage = document.createElement('img');
-    blobImage.src = window.URL.createObjectURL(file);
+    blobImage.src = currentObjectUrl;
     blobImage.dataset.jsPreview = 'true'; // JS で動的に追加した preview を識別するマーク
     blobImage.classList.add('h-full', 'w-auto', 'block', 'mx-auto', 'mt-2');
     imageContainer.appendChild(blobImage);
@@ -31,7 +44,10 @@ document.addEventListener('change', (e) => {
 
 // バックボタンキャッシュの clean up
 // ERB が描画した既存画像は残し、JS で追加した preview のみクリアする
+// 残っている object URL もここで revoke する
 document.addEventListener('turbo:before-cache', () => {
+    revokeCurrentObjectUrl();
+
     const previews = document.getElementById('new-image');
     if (previews) {
         previews.querySelectorAll('img[data-js-preview]').forEach((el) => el.remove());

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -1,45 +1,44 @@
-document.addEventListener('turbo:load', () => {
-    if (document.URL.match(/\/memories\/new/) || document.URL.match(/\/memories\/\d+\/edit/)) {
+// 画像プレビューを生成して new-image コンテナに差し替える
+function renderPreview(file) {
+    const imageContainer = document.getElementById('new-image');
+    if (!imageContainer) return;
 
-            const imageContainer = document.getElementById('new-image');
-            const imageInput = document.getElementById('memory_image');
+    // 既存の img (ERB 描画/JS 追加) を全て削除して入れ替える
+    imageContainer.innerHTML = '';
 
-            // 要素が存在しない場合は処理を中断
-            if (!imageContainer || !imageInput) return;
+    const blobImage = document.createElement('img');
+    blobImage.src = window.URL.createObjectURL(file);
+    blobImage.dataset.jsPreview = 'true'; // JS で動的に追加した preview を識別するマーク
+    blobImage.classList.add('h-full', 'w-auto', 'block', 'mx-auto', 'mt-2');
+    imageContainer.appendChild(blobImage);
 
-            // 画像表示用の関数
-            const createImageHTML = (blob) => {
-                // const imageElement = document.getElementById('new-image'); //ビューで指定したnew-imageのdiv要素を代入
-                const blobImage = document.createElement('img'); //img要素を作成
-                blobImage.setAttribute('src', blob); //imgのsrc属性にblob
-                blobImage.classList.add('h-full', 'w-auto', 'block', 'mx-auto', 'mt-2'); //画像のスタイル調整（Tailwind CSS）
-                imageContainer.appendChild(blobImage); //div要素にimg要素
-            };
-
-            // 画像が選択されたときのイベント
-            imageInput.addEventListener('change', (e) =>{
-                imageContainer.innerHTML = ""; //画像を一旦クリアする
-                const file = e.target.files[0]; //フォームで選択したファイルを取得
-                const blob =window.URL.createObjectURL(file); //選択したファイルのURLを取得
-                createImageHTML(blob); //画像表示用の関数を実行
-                // ▼ ファイル名を表示するエリアを取得して、ファイル名をセットして表示
-                const fileNameEl = document.getElementById('file-name');
-                if (fileNameEl) {
-                    fileNameEl.textContent = file.name;
-                    fileNameEl.classList.remove('hidden');
-                }
-            });
-
+    const fileNameEl = document.getElementById('file-name');
+    if (fileNameEl) {
+        fileNameEl.textContent = file.name;
+        fileNameEl.classList.remove('hidden');
     }
+}
+
+// document レベルで delegation することで、Turbo が body を置き換えた後でも
+// 新しい input 要素に対して同じハンドラが有効に動く
+// (turbo:load 内での addEventListener では再レンダリング後の要素を拾えないため)
+document.addEventListener('change', (e) => {
+    if (e.target.id !== 'memory_image') return;
+    const file = e.target.files[0];
+    if (!file) return;
+    renderPreview(file);
 });
 
-            // キャッシュ削除
-            document.addEventListener('turbo:before-cache', () => {
-                const previews = document.getElementById('new-image');
-                if (previews) previews.innerHTML = "";
-                const fileNameEl = document.getElementById('file-name');
-                if (fileNameEl) {
-                    fileNameEl.textContent = "";
-                    fileNameEl.classList.add('hidden');
-                }
-            });
+// バックボタンキャッシュの clean up
+// ERB が描画した既存画像は残し、JS で追加した preview のみクリアする
+document.addEventListener('turbo:before-cache', () => {
+    const previews = document.getElementById('new-image');
+    if (previews) {
+        previews.querySelectorAll('img[data-js-preview]').forEach((el) => el.remove());
+    }
+    const fileNameEl = document.getElementById('file-name');
+    if (fileNameEl) {
+        fileNameEl.textContent = '';
+        fileNameEl.classList.add('hidden');
+    }
+});

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -1,0 +1,17 @@
+class Child < ApplicationRecord
+  belongs_to :family_group
+
+  validates :name, presence: true, length: { maximum: 30 }
+  validate :birthday_not_in_future, if: -> { birthday.present? }
+
+  # URLのパラメータとしてuuidを使用
+  def to_param
+    uuid
+  end
+
+  private
+
+  def birthday_not_in_future
+    errors.add(:birthday, :in_future) if birthday > Date.current
+  end
+end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -1,5 +1,7 @@
 class Child < ApplicationRecord
   belongs_to :family_group
+  has_many :memory_children, dependent: :destroy
+  has_many :memories, through: :memory_children
 
   validates :name, presence: true, length: { maximum: 30 }
   validate :birthday_not_in_future, if: -> { birthday.present? }

--- a/app/models/family_group.rb
+++ b/app/models/family_group.rb
@@ -2,6 +2,7 @@ class FamilyGroup < ApplicationRecord
   has_many :user_family_groups, dependent: :destroy
   has_many :users, through: :user_family_groups
   has_many :invitations, dependent: :destroy
+  has_many :children, dependent: :destroy
 
   validates :name, presence: true
 

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -9,10 +9,14 @@ class Memory < ApplicationRecord
   belongs_to :user
   has_one_attached :image
   has_many :reactions, dependent: :destroy
+  has_many :memory_children, dependent: :destroy
+  has_many :children, through: :memory_children
 
   # imageカスタムバリデーション
   validate :image_content_type
   validate :image_size
+  # 紐付け可能なこどもは投稿者の家族グループに属するものに限定
+  validate :children_must_belong_to_user_family_group
 
   # enum公開範囲定義
   enum :visibility, {
@@ -91,5 +95,17 @@ class Memory < ApplicationRecord
   # default画像表示用メソッド
   def default_image
     "memory_placeholder.png"
+  end
+
+  # 紐付け対象のこどもは投稿者の家族グループ内に限る（フォーム改ざん防御）
+  def children_must_belong_to_user_family_group
+    return if children.empty?
+    return if user.nil?
+
+    user_group_ids = user.user_family_groups.pluck(:family_group_id)
+    invalid = children.reject { |c| user_group_ids.include?(c.family_group_id) }
+    return if invalid.empty?
+
+    errors.add(:children, :not_in_user_family_group)
   end
 end

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -11,12 +11,23 @@ class Memory < ApplicationRecord
   has_many :reactions, dependent: :destroy
   has_many :memory_children, dependent: :destroy
   has_many :children, through: :memory_children
+  has_many :memory_tags, dependent: :destroy
+  has_many :tags, through: :memory_tags
 
   # imageカスタムバリデーション
   validate :image_content_type
   validate :image_size
   # 紐付け可能なこどもは投稿者の家族グループに属するものに限定
   validate :children_must_belong_to_user_family_group
+
+  # フォームのカンマ区切り入力を受け取るための仮想 attribute
+  attr_accessor :tag_list_input
+
+  # メモリーが保存された後に、tag_list_input をもとに tags 関連を同期する
+  after_save :sync_tags_from_input
+
+  TAG_LIMIT = 10
+  TAG_MAX_LENGTH = 30
 
   # enum公開範囲定義
   enum :visibility, {
@@ -107,5 +118,21 @@ class Memory < ApplicationRecord
     return if invalid.empty?
 
     errors.add(:children, :not_in_user_family_group)
+  end
+
+  # カンマ区切り入力をパースしてタグを同期する（after_save で呼ばれる）。
+  # - 前後 strip + 重複除外
+  # - 最大 TAG_LIMIT(10) 件まで採用
+  # - TAG_MAX_LENGTH(30) 字超のタグは静かに無視（投稿そのものを失敗させない）
+  def sync_tags_from_input
+    return unless @tag_list_input.is_a?(String)
+    return if user.nil?
+
+    names = @tag_list_input.split(",").map(&:strip).reject(&:blank?).uniq
+    names = names.first(TAG_LIMIT)
+    names = names.reject { |n| n.length > TAG_MAX_LENGTH }
+
+    new_tags = names.map { |name| user.tags.find_or_create_by!(name: name) }
+    self.tags = new_tags
   end
 end

--- a/app/models/memory_child.rb
+++ b/app/models/memory_child.rb
@@ -1,0 +1,4 @@
+class MemoryChild < ApplicationRecord
+  belongs_to :memory
+  belongs_to :child
+end

--- a/app/models/memory_tag.rb
+++ b/app/models/memory_tag.rb
@@ -1,0 +1,4 @@
+class MemoryTag < ApplicationRecord
+  belongs_to :memory
+  belongs_to :tag
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,9 @@
+class Tag < ApplicationRecord
+  belongs_to :user
+  has_many :memory_tags, dependent: :destroy
+  has_many :memories, through: :memory_tags
+
+  validates :name, presence: true,
+                   length: { maximum: 30 },
+                   uniqueness: { scope: :user_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,7 @@ class User < ApplicationRecord
   has_many :user_family_groups, dependent: :destroy
   has_many :family_groups, through: :user_family_groups
   has_many :reactions, dependent: :destroy
+  has_many :tags, dependent: :destroy
 
   # バリデーション
   validates :name, presence: true

--- a/app/models/user_family_group.rb
+++ b/app/models/user_family_group.rb
@@ -24,6 +24,8 @@ class UserFamilyGroup < ApplicationRecord
   end
 
   def ensure_at_least_one_owner_remains_after_leave
+    # 親 FamilyGroup の dependent: :destroy による削除時は、個別脱退用のガードを発火させない
+    return if destroyed_by_association
     return unless owner?
     return if other_owners_exist?
 

--- a/app/policies/child_policy.rb
+++ b/app/policies/child_policy.rb
@@ -1,0 +1,28 @@
+class ChildPolicy < ApplicationPolicy
+  # 親リソース(FamilyGroup) のメンバー検証は controller の before_action で実施。
+  # ChildPolicy では「オーナーだけが書き込み可能」を表現する。
+  def index?   = true
+  def show?    = true
+  def create?  = owner_of_record_group?
+  def update?  = owner_of_record_group?
+  def destroy? = owner_of_record_group?
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope.none if user.nil?
+      # 将来「1ユーザー複数グループ」になっても壊れないよう pluck で配列取得
+      group_ids = user.user_family_groups.pluck(:family_group_id)
+      return scope.none if group_ids.empty?
+      scope.where(family_group_id: group_ids)
+    end
+  end
+
+  private
+
+  def owner_of_record_group?
+    return false if user.nil?
+    user.user_family_groups.exists?(
+      family_group_id: record.family_group_id, role: :owner
+    )
+  end
+end

--- a/app/views/children/_form.html.erb
+++ b/app/views/children/_form.html.erb
@@ -1,0 +1,25 @@
+<%= form_with model: [@family_group, @child] do |f| %>
+  <%= render "shared/error_messages", object: f.object %>
+
+  <div class="form-control gap-1">
+    <%= f.label :name, class: "label py-0" do %>
+      <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60"><%= t("activerecord.attributes.child.name") %></span>
+    <% end %>
+    <%= f.text_field :name,
+          placeholder: t("children.form.name_placeholder"),
+          class: "input input-bordered input-sm bg-base-200/50 focus:bg-base-100 focus:input-primary transition-all duration-200 w-full" %>
+  </div>
+
+  <div class="form-control gap-1">
+    <%= f.label :birthday, class: "label py-0" do %>
+      <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60"><%= t("activerecord.attributes.child.birthday") %></span>
+    <% end %>
+    <%= f.date_field :birthday,
+          class: "input input-bordered input-sm bg-base-200/50 focus:bg-base-100 focus:input-primary transition-all duration-200 w-full" %>
+  </div>
+
+  <div class="flex justify-end gap-2 pt-1 border-t border-base-200">
+    <%= link_to t("helpers.submit.cancel"), family_group_children_path(@family_group), class: "btn btn-ghost btn-sm" %>
+    <%= f.submit class: "btn btn-primary btn-sm px-6" %>
+  </div>
+<% end %>

--- a/app/views/children/edit.html.erb
+++ b/app/views/children/edit.html.erb
@@ -1,0 +1,26 @@
+<div class="min-h-screen bg-base-200 flex justify-center py-6 px-4">
+  <div class="fixed inset-0 overflow-hidden pointer-events-none">
+    <div class="absolute -top-24 -right-24 w-96 h-96 rounded-full opacity-10 bg-primary blur-3xl"></div>
+    <div class="absolute -bottom-24 -left-24 w-96 h-96 rounded-full opacity-10 bg-secondary blur-3xl"></div>
+  </div>
+
+  <div class="relative w-full max-w-2xl">
+    <div class="flex items-center gap-3 mb-4">
+      <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-primary/10 shrink-0">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-primary" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z" />
+        </svg>
+      </div>
+      <div>
+        <h1 class="text-xl font-bold tracking-tight leading-tight"><%= t("children.edit.title") %></h1>
+        <p class="text-base-content/50 text-xs"><%= t("children.edit.subtitle") %></p>
+      </div>
+    </div>
+
+    <div class="card bg-base-100 shadow-2xl border border-base-200">
+      <div class="card-body p-6 gap-4">
+        <%= render "form" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/children/index.html.erb
+++ b/app/views/children/index.html.erb
@@ -1,0 +1,75 @@
+<div class="min-h-screen bg-base-200 flex justify-center py-6 px-4">
+  <div class="fixed inset-0 overflow-hidden pointer-events-none">
+    <div class="absolute -top-24 -right-24 w-96 h-96 rounded-full opacity-10 bg-primary blur-3xl"></div>
+    <div class="absolute -bottom-24 -left-24 w-96 h-96 rounded-full opacity-10 bg-secondary blur-3xl"></div>
+  </div>
+
+  <div class="relative w-full max-w-2xl">
+    <div class="flex items-center gap-3 mb-4">
+      <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-primary/10 shrink-0">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-primary" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z" />
+        </svg>
+      </div>
+      <div class="flex-1">
+        <h1 class="text-xl font-bold tracking-tight leading-tight"><%= t("children.index.title") %></h1>
+        <p class="text-base-content/50 text-xs"><%= t("children.index.subtitle", group_name: @family_group.name) %></p>
+      </div>
+      <% if policy(Child.new(family_group: @family_group)).create? %>
+        <%= link_to new_family_group_child_path(@family_group), class: "btn btn-primary btn-sm" do %>
+          + <%= t("children.index.add") %>
+        <% end %>
+      <% end %>
+    </div>
+
+    <% unless policy(Child.new(family_group: @family_group)).create? %>
+      <div class="alert alert-info alert-soft text-xs mb-4">
+        <%= t("children.index.member_notice") %>
+      </div>
+    <% end %>
+
+    <% if @children.empty? %>
+      <div class="card bg-base-100 shadow-2xl border border-base-200">
+        <div class="card-body p-6 gap-2 items-center text-center">
+          <p class="text-base-content/50 text-sm"><%= t("children.index.empty") %></p>
+        </div>
+      </div>
+    <% else %>
+      <div class="grid gap-3">
+        <% @children.each do |child| %>
+          <div class="card bg-base-100 shadow-xl border border-base-200">
+            <div class="card-body p-4 flex-row items-center gap-3">
+              <div class="inline-flex items-center justify-center w-10 h-10 rounded-full bg-primary/10 shrink-0">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-primary" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z" />
+                </svg>
+              </div>
+              <div class="flex-1 min-w-0">
+                <p class="font-semibold text-base truncate"><%= child.name %></p>
+                <% if child.birthday.present? %>
+                  <p class="text-base-content/50 text-xs">
+                    <%= l(child.birthday, format: :long) %>
+                  </p>
+                <% end %>
+              </div>
+              <% if policy(child).update? %>
+                <%= link_to t("helpers.submit.edit"), edit_family_group_child_path(@family_group, child), class: "btn btn-ghost btn-xs" %>
+              <% end %>
+              <% if policy(child).destroy? %>
+                <%= button_to t("helpers.submit.delete"),
+                              family_group_child_path(@family_group, child),
+                              method: :delete,
+                              form: { data: { turbo_confirm: t("defaults.delete_confirm") } },
+                              class: "btn btn-ghost btn-xs text-error" %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+
+    <div class="flex justify-end mt-4">
+      <%= link_to t("children.index.back_to_mypage"), mypage_path, class: "btn btn-ghost btn-sm" %>
+    </div>
+  </div>
+</div>

--- a/app/views/children/new.html.erb
+++ b/app/views/children/new.html.erb
@@ -1,0 +1,26 @@
+<div class="min-h-screen bg-base-200 flex justify-center py-6 px-4">
+  <div class="fixed inset-0 overflow-hidden pointer-events-none">
+    <div class="absolute -top-24 -right-24 w-96 h-96 rounded-full opacity-10 bg-primary blur-3xl"></div>
+    <div class="absolute -bottom-24 -left-24 w-96 h-96 rounded-full opacity-10 bg-secondary blur-3xl"></div>
+  </div>
+
+  <div class="relative w-full max-w-2xl">
+    <div class="flex items-center gap-3 mb-4">
+      <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-primary/10 shrink-0">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-primary" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z" />
+        </svg>
+      </div>
+      <div>
+        <h1 class="text-xl font-bold tracking-tight leading-tight"><%= t("children.new.title") %></h1>
+        <p class="text-base-content/50 text-xs"><%= t("children.new.subtitle") %></p>
+      </div>
+    </div>
+
+    <div class="card bg-base-100 shadow-2xl border border-base-200">
+      <div class="card-body p-6 gap-4">
+        <%= render "form" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/dashboard/top.html.erb
+++ b/app/views/dashboard/top.html.erb
@@ -99,8 +99,8 @@
       <%= link_to memory_game_path, class: "card bg-base-100 shadow-xl hover:shadow-2xl hover:-translate-y-1 transition border-l-4 border-accent" do %>
         <div class="card-body gap-3">
           <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-accent/10 shrink-0 self-start">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-accent" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z" />
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-accent fill-current" viewBox="0 0 24 24">
+              <path d="M21.58,16.09l-1.09-7.66C20.21,6.46,18.52,5,16.53,5H7.47C5.48,5,3.79,6.46,3.51,8.43l-1.09,7.66C2.2,17.63,3.39,19,4.94,19h0c0.68,0,1.32-0.27,1.8-0.75L9,16h6l2.25,2.25c0.48,0.48,1.13,0.75,1.8,0.75h0C20.61,19,21.8,17.63,21.58,16.09z M11,11H9v2H8v-2H6v-1h2V8h1v2h2V11z M15,10c-0.55,0-1-0.45-1-1c0-0.55,0.45-1,1-1s1,0.45,1,1C16,9.55,15.55,10,15,10z M17,13c-0.55,0-1-0.45-1-1c0-0.55,0.45-1,1-1s1,0.45,1,1C18,12.55,17.55,13,17,13z"/>
             </svg>
           </div>
           <div>

--- a/app/views/memories/_child_selector.html.erb
+++ b/app/views/memories/_child_selector.html.erb
@@ -1,0 +1,41 @@
+<%# 投稿者の家族グループに属するこどもをバッジ形式で選択する UI %>
+<% if @available_children.present? %>
+  <div class="form-control gap-1" data-controller="memory-children">
+    <div class="flex items-center justify-between">
+      <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60">
+        <%= t("memories.form.children_label") %>
+      </span>
+      <button type="button"
+              data-action="click->memory-children#selectAll"
+              class="btn btn-ghost btn-xs">
+        <%= t("memories.form.select_all_children") %>
+      </button>
+    </div>
+
+    <div class="flex flex-wrap gap-2 pt-1">
+      <% @available_children.each do |child| %>
+        <% selected = @memory.children.include?(child) %>
+        <button type="button"
+                data-action="click->memory-children#toggle"
+                data-memory-children-target="badge"
+                data-child-id="<%= child.id %>"
+                data-selected="<%= selected %>"
+                class="badge badge-lg gap-1 cursor-pointer <%= selected ? 'badge-primary' : 'badge-outline' %>">
+          <%= child.name %>
+        </button>
+      <% end %>
+    </div>
+
+    <!-- hidden inputを格納するコンテナ -->
+    <div data-memory-children-target="container">
+      <%# 空配列を送信するための要素 %>
+      <input type="hidden" name="memory[child_ids][]" value="">
+      <% @memory.children.each do |child| %>
+        <input type="hidden"
+               name="memory[child_ids][]"
+               value="<%= child.id %>"
+               data-child-id="<%= child.id %>">
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/memories/_tag_input.html.erb
+++ b/app/views/memories/_tag_input.html.erb
@@ -5,8 +5,9 @@
       <%= t("memories.form.tag_list_label") %>
     </span>
   <% end %>
+  <%# バリデーション失敗時はユーザー入力(tag_list_input)を優先表示。通常時は DB の tags から組み立てる %>
   <%= f.text_field :tag_list_input,
-        value: f.object.tags.map(&:name).join(", "),
+        value: f.object.tag_list_input.presence || f.object.tags.map(&:name).join(", "),
         placeholder: t("memories.form.tag_list_placeholder"),
         class: "input input-bordered input-sm bg-base-200/50 focus:bg-base-100 focus:input-primary transition-all duration-200 w-full" %>
   <p class="text-xs text-base-content/50 mt-1"><%= t("memories.form.tag_list_hint") %></p>

--- a/app/views/memories/_tag_input.html.erb
+++ b/app/views/memories/_tag_input.html.erb
@@ -1,0 +1,13 @@
+<%# タグ入力フィールド（投稿/編集共通） %>
+<div class="form-control gap-1">
+  <%= f.label :tag_list_input, class: "label py-0" do %>
+    <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60">
+      <%= t("memories.form.tag_list_label") %>
+    </span>
+  <% end %>
+  <%= f.text_field :tag_list_input,
+        value: f.object.tags.map(&:name).join(", "),
+        placeholder: t("memories.form.tag_list_placeholder"),
+        class: "input input-bordered input-sm bg-base-200/50 focus:bg-base-100 focus:input-primary transition-all duration-200 w-full" %>
+  <p class="text-xs text-base-content/50 mt-1"><%= t("memories.form.tag_list_hint") %></p>
+</div>

--- a/app/views/memories/edit.html.erb
+++ b/app/views/memories/edit.html.erb
@@ -124,6 +124,9 @@
               <!-- ファイル名表示（新規選択時） -->
               <p id="file-name" class="hidden text-xs text-base-content/50 text-center truncate px-2"></p>
 
+              <%# バリデーション失敗時に新規選択画像(in-memory attachment) を保持。
+                  id は file_field と衝突させないため別名にする(label[for] が hidden を拾うのを防ぐ) %>
+              <%= f.hidden_field :image, value: @memory.image.signed_id, id: "memory_image_signed_id" if @memory.image.attached? && @memory.image.blob&.persisted? %>
               <%= f.file_field :image,
                     id: "memory_image",
                     direct_upload: true,

--- a/app/views/memories/edit.html.erb
+++ b/app/views/memories/edit.html.erb
@@ -90,6 +90,8 @@
 
           <%= render "child_selector" %>
 
+          <%= render "tag_input", f: f %>
+
           <!-- 画像アップロード -->
           <div class="form-control gap-1">
             <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60"><%= t('helpers.label.image') %></span>

--- a/app/views/memories/edit.html.erb
+++ b/app/views/memories/edit.html.erb
@@ -88,6 +88,8 @@
             </div>
           </div>
 
+          <%= render "child_selector" %>
+
           <!-- 画像アップロード -->
           <div class="form-control gap-1">
             <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60"><%= t('helpers.label.image') %></span>

--- a/app/views/memories/new.html.erb
+++ b/app/views/memories/new.html.erb
@@ -90,6 +90,8 @@
 
           <%= render "child_selector" %>
 
+          <%= render "tag_input", f: f %>
+
           <!-- 画像アップロード -->
           <div class="form-control gap-1">
             <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60"><%= t('helpers.label.image') %></span>

--- a/app/views/memories/new.html.erb
+++ b/app/views/memories/new.html.erb
@@ -88,6 +88,8 @@
             </div>
           </div>
 
+          <%= render "child_selector" %>
+
           <!-- 画像アップロード -->
           <div class="form-control gap-1">
             <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60"><%= t('helpers.label.image') %></span>

--- a/app/views/memories/new.html.erb
+++ b/app/views/memories/new.html.erb
@@ -113,10 +113,20 @@
               </div>
 
               <%# ▼ プレビュー エリア ▼ %>
-              <div id="new-image" class="w-full rounded-lg overflow-hidden empty:hidden [&:not(:empty)]:h-32"></div>
+              <%# new では @memory が未保存のため display_image(variant) は signed_id 取得で失敗する %>
+              <%# blob から直接 URL を取り、ブラウザ側でプレビューさせる %>
+              <div id="new-image" class="w-full rounded-lg overflow-hidden empty:hidden [&:not(:empty)]:h-32">
+                <% if @memory.image.attached? && @memory.image.blob&.persisted? %>
+                  <%= image_tag rails_blob_url(@memory.image.blob, only_path: true), class: "h-full mx-auto object-cover" %>
+                <% end %>
+              </div>
               <%# ▼ ファイル名表示エリア ▼ %>
                 <p id="file-name" class="hidden text-xs text-base-content/50 text-center truncate px-2"></p>
 
+              <%# バリデーション失敗時に既存 attachment を保持(blob は事前に永続化済み)。
+                  HTML順で hidden→file_field の順なので、新ファイル選択時は direct_upload の値が後勝ち。
+                  id は file_field と衝突させないため別名にする(label[for] が hidden を拾うのを防ぐ) %>
+              <%= f.hidden_field :image, value: @memory.image.signed_id, id: "memory_image_signed_id" if @memory.image.attached? && @memory.image.blob&.persisted? %>
               <%= f.file_field :image,
                     id: "memory_image",
                     direct_upload: true,

--- a/app/views/memories/show.html.erb
+++ b/app/views/memories/show.html.erb
@@ -67,6 +67,20 @@
         </div>
       <% end %>
 
+      <%# タグ（こども同様、掲示板/public_memories#show では描画されない） %>
+      <% if @memory.tags.any? %>
+        <div>
+          <p class="text-xs font-bold tracking-widest text-base-content/40 mb-3">
+            <%= t('memories.show.tags_label') %>
+          </p>
+          <div class="flex flex-wrap gap-x-3 gap-y-1 text-sm text-secondary">
+            <% @memory.tags.each do |tag| %>
+              <span>#<%= tag.name %></span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+
       <%# エピソード %>
       <div>
         <p class="text-xs font-bold tracking-widest text-base-content/40 mb-3">

--- a/app/views/memories/show.html.erb
+++ b/app/views/memories/show.html.erb
@@ -53,6 +53,20 @@
         </span>
       </div>
 
+      <%# こども（掲示板/public_memories#show では描画されない） %>
+      <% if @memory.children.any? %>
+        <div>
+          <p class="text-xs font-bold tracking-widest text-base-content/40 mb-3">
+            <%= t('memories.show.children_label') %>
+          </p>
+          <div class="flex flex-wrap gap-2">
+            <% @memory.children.each do |child| %>
+              <span class="badge badge-primary badge-lg"><%= child.name %></span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+
       <%# エピソード %>
       <div>
         <p class="text-xs font-bold tracking-widest text-base-content/40 mb-3">

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -95,5 +95,38 @@
       </div>
     <% end %>
 
+    <!-- こどもセクション -->
+    <div class="flex items-center gap-3 mt-6 mb-4">
+      <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-primary/10 shrink-0">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-primary" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z" />
+        </svg>
+      </div>
+      <div>
+        <h2 class="text-xl font-bold tracking-tight leading-tight"><%= t('mypage.children.title') %></h2>
+        <p class="text-base-content/50 text-xs"><%= t('mypage.children.subtitle') %></p>
+      </div>
+    </div>
+
+    <% if @family_group %>
+      <div class="card bg-base-100 shadow-2xl border border-base-200">
+        <div class="card-body p-6 gap-4">
+          <p class="text-base-content/70 text-sm">
+            <%= t('mypage.children.count', count: @family_group.children.count) %>
+          </p>
+          <div class="flex justify-end pt-1 border-t border-base-200">
+            <%= link_to t('mypage.children.view_list'), family_group_children_path(@family_group), class: "btn btn-primary btn-sm px-6" %>
+          </div>
+        </div>
+      </div>
+    <% else %>
+      <div class="card bg-base-100 shadow-2xl border border-base-200">
+        <div class="card-body p-6 gap-2 items-center text-center">
+          <p class="text-base-content/50 text-sm"><%= t('mypage.children.requires_group') %></p>
+          <p class="text-base-content/40 text-xs"><%= t('mypage.children.requires_group_subtitle') %></p>
+        </div>
+      </div>
+    <% end %>
+
   </div>
 </div>

--- a/app/views/public_memories/show.html.erb
+++ b/app/views/public_memories/show.html.erb
@@ -53,6 +53,20 @@
         </span>
       </div>
 
+      <%# タグ %>
+      <% if @memory.tags.any? %>
+        <div>
+          <p class="text-xs font-bold tracking-widest text-base-content/40 mb-3">
+            <%= t('memories.show.tags_label') %>
+          </p>
+          <div class="flex flex-wrap gap-x-3 gap-y-1 text-sm text-secondary">
+            <% @memory.tags.each do |tag| %>
+              <span>#<%= tag.name %></span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+
       <%# エピソード %>
       <div>
         <p class="text-xs font-bold tracking-widest text-base-content/40 mb-3">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -45,8 +45,8 @@
       <%# 楽しむボタン %>
       <%= link_to memory_game_path, class: "flex flex-col items-center justify-center text-xs #{active_if("memory_games")}" do %>
         <span class="text-xl">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z" />
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 fill-current" viewBox="0 0 24 24">
+              <path d="M21.58,16.09l-1.09-7.66C20.21,6.46,18.52,5,16.53,5H7.47C5.48,5,3.79,6.46,3.51,8.43l-1.09,7.66C2.2,17.63,3.39,19,4.94,19h0c0.68,0,1.32-0.27,1.8-0.75L9,16h6l2.25,2.25c0.48,0.48,1.13,0.75,1.8,0.75h0C20.61,19,21.8,17.63,21.58,16.09z M11,11H9v2H8v-2H6v-1h2V8h1v2h2V11z M15,10c-0.55,0-1-0.45-1-1c0-0.55,0.45-1,1-1s1,0.45,1,1C16,9.55,15.55,10,15,10z M17,13c-0.55,0-1-0.45-1-1c0-0.55,0.45-1,1-1s1,0.45,1,1C18,12.55,17.55,13,17,13z"/>
           </svg>
         </span>
         <span><%= t('footer.enjoy') %></span>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -5,6 +5,7 @@ ja:
       memory: 思い出
       reaction: リアクション
       child: こども
+      tag: タグ
     attributes:
       user:
         email: メールアドレス
@@ -24,6 +25,8 @@ ja:
       child:
         name: 名前
         birthday: 生年月日
+      tag:
+        name: タグ名
     errors:
       models:
         reaction:

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -4,6 +4,7 @@ ja:
       user: ユーザー
       memory: 思い出
       reaction: リアクション
+      child: こども
     attributes:
       user:
         email: メールアドレス
@@ -20,12 +21,19 @@ ja:
         role: 役割
       reaction:
         reaction_type: リアクションの種類
+      child:
+        name: 名前
+        birthday: 生年月日
     errors:
       models:
         reaction:
           attributes:
             base:
               own_post: 自分の投稿にはリアクションできません
+        child:
+          attributes:
+            birthday:
+              in_future: は未来の日付を指定できません
   enums:
     memory:
       visibility:

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -34,6 +34,10 @@ ja:
           attributes:
             birthday:
               in_future: は未来の日付を指定できません
+        memory:
+          attributes:
+            children:
+              not_in_user_family_group: には所属していない家族グループのこどもを指定できません
   enums:
     memory:
       visibility:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -87,11 +87,34 @@ ja:
     disabled_reason:
       own_post: 自分の投稿にはリアクションできません
       not_logged_in: ログインするとリアクションできます
+  children:
+    index:
+      title: こども一覧
+      subtitle: "「%{group_name}」のこどもを管理できます"
+      add: こどもを追加
+      empty: まだこどもが登録されていません
+      member_notice: こどもの追加・編集はグループのオーナーのみ可能です
+      back_to_mypage: マイページに戻る
+    new:
+      title: こども新規登録
+      subtitle: 家族グループにこどもを追加します
+    edit:
+      title: こども編集
+      subtitle: こどもの情報を編集します
+    form:
+      name_placeholder: こどもの名前を入力
   mypage:
     account_title: プロフィール
     account_subtitle: アカウント情報を確認できます
     user_name: ユーザー名
     avatar: アバター画像
+    children:
+      title: こども
+      subtitle: 家族で共有するこどもを管理できます
+      count: "%{count}人登録されています"
+      view_list: こども一覧を見る
+      requires_group: こどもの登録には家族グループへの所属が必要です
+      requires_group_subtitle: 家族グループを作成または参加してください
     family_group:
       title: 家族グループ
       subtitle: グループを作成・管理できます

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -75,9 +75,13 @@ ja:
     show:
       return_to_list: 一覧に戻る
       children_label: こども
+      tags_label: タグ
     form:
       children_label: こども (任意)
       select_all_children: 全員
+      tag_list_label: タグ (任意)
+      tag_list_placeholder: "例: 石, お花屋さん, 帰り道"
+      tag_list_hint: カンマ区切りで最大10個まで。30文字を超えるタグは反映されません
   public_memories:
     index:
       title: 掲示板

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -74,6 +74,10 @@ ja:
       subtitle: 内容を編集できます
     show:
       return_to_list: 一覧に戻る
+      children_label: こども
+    form:
+      children_label: こども (任意)
+      select_all_children: 全員
   public_memories:
     index:
       title: 掲示板

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,9 @@ Rails.application.routes.draw do
   resources :family_groups, param: :uuid, only: %i[new create update show destroy] do
     # メンバーシップ操作（役割変更・脱退）。member 中間テーブルのため id は数値 ID。
     resources :user_family_groups, only: %i[update destroy]
+
+    # こども管理 - uuidをURLパラメータとして使用するため、param: :uuidを指定
+    resources :children, param: :uuid, only: %i[index new create edit update destroy]
   end
 
   get "memory_game" => "memory_games#show", as: :memory_game

--- a/db/migrate/20260520143244_create_children.rb
+++ b/db/migrate/20260520143244_create_children.rb
@@ -1,0 +1,14 @@
+class CreateChildren < ActiveRecord::Migration[7.2]
+  def change
+    create_table :children do |t|
+      t.uuid :uuid, default: "gen_random_uuid()", null: false
+      t.references :family_group, null: false, foreign_key: true
+      t.string :name, null: false
+      t.date :birthday
+
+      t.timestamps
+    end
+
+    add_index :children, :uuid, unique: true
+  end
+end

--- a/db/migrate/20260522153523_create_memory_children.rb
+++ b/db/migrate/20260522153523_create_memory_children.rb
@@ -1,0 +1,10 @@
+class CreateMemoryChildren < ActiveRecord::Migration[7.2]
+  def change
+    create_table :memory_children do |t|
+      t.references :memory, null: false, foreign_key: true
+      t.references :child,  null: false, foreign_key: true
+      t.timestamps
+      t.index [ :memory_id, :child_id ], unique: true
+    end
+  end
+end

--- a/db/migrate/20260524073154_create_tags.rb
+++ b/db/migrate/20260524073154_create_tags.rb
@@ -1,0 +1,11 @@
+class CreateTags < ActiveRecord::Migration[7.2]
+  def change
+    create_table :tags do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :name, null: false
+      t.timestamps
+    end
+
+    add_index :tags, [ :user_id, :name ], unique: true
+  end
+end

--- a/db/migrate/20260524073155_create_memory_tags.rb
+++ b/db/migrate/20260524073155_create_memory_tags.rb
@@ -1,0 +1,11 @@
+class CreateMemoryTags < ActiveRecord::Migration[7.2]
+  def change
+    create_table :memory_tags do |t|
+      t.references :memory, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+      t.timestamps
+    end
+
+    add_index :memory_tags, [ :memory_id, :tag_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_22_153523) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_24_073155) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -95,6 +95,16 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_22_153523) do
     t.index ["memory_id"], name: "index_memory_children_on_memory_id"
   end
 
+  create_table "memory_tags", force: :cascade do |t|
+    t.bigint "memory_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["memory_id", "tag_id"], name: "index_memory_tags_on_memory_id_and_tag_id", unique: true
+    t.index ["memory_id"], name: "index_memory_tags_on_memory_id"
+    t.index ["tag_id"], name: "index_memory_tags_on_tag_id"
+  end
+
   create_table "reactions", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "memory_id", null: false
@@ -104,6 +114,15 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_22_153523) do
     t.index ["memory_id"], name: "index_reactions_on_memory_id"
     t.index ["user_id", "memory_id", "reaction_type"], name: "index_reactions_on_user_id_and_memory_id_and_reaction_type", unique: true
     t.index ["user_id"], name: "index_reactions_on_user_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "name"], name: "index_tags_on_user_id_and_name", unique: true
+    t.index ["user_id"], name: "index_tags_on_user_id"
   end
 
   create_table "user_family_groups", force: :cascade do |t|
@@ -140,8 +159,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_22_153523) do
   add_foreign_key "memories", "users"
   add_foreign_key "memory_children", "children"
   add_foreign_key "memory_children", "memories"
+  add_foreign_key "memory_tags", "memories"
+  add_foreign_key "memory_tags", "tags"
   add_foreign_key "reactions", "memories"
   add_foreign_key "reactions", "users"
+  add_foreign_key "tags", "users"
   add_foreign_key "user_family_groups", "family_groups"
   add_foreign_key "user_family_groups", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_20_143244) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_22_153523) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -85,6 +85,16 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_20_143244) do
     t.index ["uuid"], name: "index_memories_on_uuid", unique: true
   end
 
+  create_table "memory_children", force: :cascade do |t|
+    t.bigint "memory_id", null: false
+    t.bigint "child_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["child_id"], name: "index_memory_children_on_child_id"
+    t.index ["memory_id", "child_id"], name: "index_memory_children_on_memory_id_and_child_id", unique: true
+    t.index ["memory_id"], name: "index_memory_children_on_memory_id"
+  end
+
   create_table "reactions", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "memory_id", null: false
@@ -128,6 +138,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_20_143244) do
   add_foreign_key "children", "family_groups"
   add_foreign_key "invitations", "family_groups"
   add_foreign_key "memories", "users"
+  add_foreign_key "memory_children", "children"
+  add_foreign_key "memory_children", "memories"
   add_foreign_key "reactions", "memories"
   add_foreign_key "reactions", "users"
   add_foreign_key "user_family_groups", "family_groups"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_16_160637) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_20_143244) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -41,6 +41,17 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_16_160637) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "children", force: :cascade do |t|
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.bigint "family_group_id", null: false
+    t.string "name", null: false
+    t.date "birthday"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["family_group_id"], name: "index_children_on_family_group_id"
+    t.index ["uuid"], name: "index_children_on_uuid", unique: true
   end
 
   create_table "family_groups", force: :cascade do |t|
@@ -114,6 +125,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_16_160637) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "children", "family_groups"
   add_foreign_key "invitations", "family_groups"
   add_foreign_key "memories", "users"
   add_foreign_key "reactions", "memories"


### PR DESCRIPTION
## 概要
- こども管理機能(Phase 1)・ミニメモリへのこども紐付け(Phase 2)・タグ機能(Phase A)を含む 3 つの新機能 を追加                                           
- 家族グループ削除時の before_destroy ガード暴発、OGP 画像 URL の signed_id エラー、バリデーション失敗時の添付画像消失など 3 件のバグ修正 を含む
- 新規テーブル 4 つ(children / memory_children / tags / memory_tags)を追加

### 関連PR                                                                                                                                          
                                                                                                                    
  - #234 [Feature] 家族グループ配下にこども管理機能を追加 (Phase 1)                                                                                     
  - #237 [Fix] 最後のオーナーガードでグループ削除が失敗するのを修正
  - #238 [Feature] ミニメモリにこども紐付け機能を追加 (Phase 2)                                                                                         
  - #239 [Feature] ミニメモリにタグ機能を追加 (Phase A)                                                                                                 
  - #240 [Fix] 未保存メモリの OGP 画像 URL 生成で signed_id エラーを修正                                                                                
  - #241 [Fix] バリデーション失敗時にミニメモリの添付画像を保持                                                                                   
                                                                                                                                                        
###  主な変更点                                                                                                                                            
                                                                                                                                                        
####  認可（Pundit）                                                                                                    
                                                               
  - ChildPolicy 新規: メンバーは閲覧可、オーナーのみ書き込み可                                                                                          
  - ChildPolicy::Scope は pluck(:family_group_id) で配列取得し、将来「1 ユーザー 複数グループ」拡張に耐える書き方
  - ChildrenController#set_family_group で policy_scope(FamilyGroup).find_by! を使い、非メンバーは 404(存在隠蔽)                                        
  - Memory#children_must_belong_to_user_family_group validation で他家族 child_id の改ざん送信を弾く(policy_scope と二段防衛)                           
  - Tag は Memory フォームの仮想 attribute(tag_list_input)経由でしか操作されないため、TagPolicy は意図的に作らない                                      
                                                                                                                                                        
 #### モデル / DB                                                                                                                                           
                                                                                                                                                        
  - 新規テーブル 4 種(すべて複合 unique index で重複防御)                                                                                               
    - children (uuid, family_group_id, name, birthday)         
    - memory_children (memory_id, child_id)                                                                                                             
    - tags (user_id, name)                                                                                                                              
    - memory_tags (memory_id, tag_id)                                                                                                                   
  - Child モデル: 名前必須(30 字以内)、生年月日は任意・未来日付不可、URL 識別子は uuid                                                                  
  - Tag モデル: 名前必須(30 字以内)、uniqueness: { scope: :user_id }                                                                                    
  - Memory に has_many :children, through: :memory_children と has_many :tags, through: :memory_tags を追加                                             
  - Memory#tag_list_input 仮想 attribute + after_save :sync_tags_from_input でカンマ区切り入力を Tag 群に同期(strip / uniq / 最大 10 個 / 30 字超は無視)
  - FamilyGroup に has_many :children, dependent: :destroy                                                                                              
  - User に has_many :tags, dependent: :destroy                                                                                                         
  - UserFamilyGroup#ensure_at_least_one_owner_remains_after_leave に destroyed_by_association チェックを追加し、親 FamilyGroup の dependent: :destroy   
  経由ではガードを発火させない                                                                                                                          
                                                                                                                                                        
 #### コントローラ / ルーティング                                                                                                                           
                                                                                                                    
  - resources :family_groups 配下に nested で resources :children, param: :uuid                                                                         
  - MemoriesController#memory_params に child_ids: [] と :tag_list_input を許可
  - MemoriesController で params[:memory][:image].is_a?(ActionDispatch::Http::UploadedFile) 判定により、multipart upload と direct_upload (signed_id    
  文字列)を分岐                                                                                                                                         
  - MemoriesController#attach_processed_image! ヘルパーで ActiveStorage::Blob.create_and_upload! を呼び、blob を DB + storage                           
  に即時永続化(バリデーション失敗時のプレビュー復元用)                                                                                                  
  - ActiveStorage::Error / ActiveRecord::RecordInvalid を ImageProcessable::ImageProcessingError にラップして既存 rescue に接続
  - ApplicationHelper#ogp_image_url に @memory.persisted? チェックを追加して new record での signed_id 取得失敗を防止                                   
                                                                                                                                                        
 #### ビュー / UI                                                                                                                                           
                                                                                                                                                        
  - マイページに「こども」セクションを追加(所属時=人数とリンク、未所属時=注意書き + 作成導線)                                                           
  - セクションヘッダのアイコンを heroicons の face-smile に統一、ゲーム/楽しむ系アイコンと衝突するため後者は Material Icons の sports_esports に変更
  - ミニメモリ投稿/編集フォームに こども選択 UI(バッジ + 「全員」ボタン)を追加、Stimulus(memory-children controller)で hidden_input を動的生成/削除     
  - フォームに タグ入力欄(カンマ区切りテキスト)を追加、プレースホルダーは「石, お花屋さん, 帰り道」、ヒント文に「最大 10 個、30                         
  字超は反映されない」を明記                                                                                                                            
  - 詳細画面(memories#show)で こどもバッジ(badge-primary)と タグ(#xxx ハッシュタグ形式)を表示                                                           
  - 掲示板(public_memories#show)では タグのみ表示、こどもは個人特定情報のため非表示(プライバシー配慮)                                                   
  - フォーム共通化のため _child_selector.html.erb / _tag_input.html.erb をパーシャル化し、new / edit から render                                        
  - 画像保持のため f.hidden_field :image を id: "memory_image_signed_id" 別名で追加(label[for] が hidden を吸って file                                  
  選択ダイアログが開かなくなる衝突を回避)                                                                                                               
  - new の画像プレビューは display_image(variant)ではなく rails_blob_url(blob) で組み立て(未保存メモリの signed_id 取得失敗を回避)                      
  - preview.js を event delegation 方式 に書き換え、Turbo Drive の 422 で body 置き換え後の新しい file_field でも change を拾えるように                 
  - preview.js で生成した object URL を URL.revokeObjectURL で解放(メモリリーク防止)                                                                    
                                                                                                                                                        
 #### Stimulus                                                                                                                                              
                                                                                                                                                        
  - app/javascript/controllers/memory_children_controller.js 新規: バッジクリックで hidden_input を動的生成/削除、「全員」ボタンで一括追加              
                                                               
 #### i18n                                                                                                                                                  
                                                                                                                    
  - config/locales/activerecord/ja.yml: child / tag のモデル名・属性名、Child#birthday#in_future / Memory#children#not_in_user_family_group のエラーキー
  - config/locales/views/ja.yml: マイページ children
  セクション、children.index/new/edit/form、memories.form.tag_list_*、memories.show.children_label/tags_label                                           
                                                                                                                    
 ### 動作確認済み（develop 上）                                                                                                                            
                                                                                                                    
  - オーナーでこども CRUD 全操作可能、メンバーは閲覧のみで操作ボタン非表示                                                                              
  - 非メンバー/未所属ユーザーで /family_groups/:uuid/children に直接アクセスして 404
  - グループ削除時にこどもがカスケード削除される                                                                                                        
  - オーナー 1 人のグループも「グループを解散する」で削除成功(個別脱退は引き続き不可)                                                                   
  - ミニメモリ投稿時にこども 0 / 1 / 複数選択で正しく中間テーブルに INSERT/DELETE                                                                       
  - 「全員」ボタンで一括選択、編集で追加/削除/全解除がすべて反映                                                                                        
  - DevTools で他家族の child_id を仕込んで送信 → モデル validation で弾かれる                                                                          
  - タグをカンマ区切りで入力 → strip / uniq / 最大 10 個 / 30 字超無視がすべて期待通り動作                                                              
  - 同じユーザーが同名タグを再使用 → tags テーブルは 1 行で再利用、別ユーザーは別レコードで共存                                                         
  - memories#show でこどもバッジとハッシュタグ(#石 #お花屋さん)が表示                                                                                   
  - public_memories#show ではこどもは非表示、タグはハッシュタグで表示                                                                                   
  - タイトル空欄 + 画像添付で submit → 500 にならずバリデーションエラー画面が出る(OGP signed_id 修正)                                                   
  - バリデーション失敗時に画像プレビューが保持され、画像再選択でプレビューが切り替わる                                                                  
  - そのままタイトル入力して再送信 → 画像を再選択せず投稿成功                                                                                           
  - 既存ミニメモリー(こども・タグ未紐付け)が一覧・詳細で壊れていない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * こども情報の登録・編集・削除機能を追加
  * メモへのタグ付け機能を実装
  * メモにこどもを関連付ける機能を追加

* **改善**
  * 画像プレビューのメモリリーク対策を強化

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tantp-1111/mini_memory/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->