### PR TITLE
投稿一覧にキーワード検索を追加(ransack 導入)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,9 @@ gem "meta-tags"
 # Pundit - 認可（Policy ベース）
 gem "pundit"
 
+# Ransack - 検索クエリビルダー
+gem "ransack"
+
 group :development, :test do
   # debug - デバッグツール
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,6 +315,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.1)
+    ransack (4.4.1)
+      activerecord (>= 7.2)
+      activesupport (>= 7.2)
+      i18n
     rdoc (7.1.0)
       erb
       psych (>= 4.0.0)
@@ -453,6 +457,7 @@ DEPENDENCIES
   pundit
   rails (~> 7.2.2)
   rails-i18n
+  ransack
   rubocop-rails-omakase
   selenium-webdriver
   sprockets-rails

--- a/app/controllers/family_memories_controller.rb
+++ b/app/controllers/family_memories_controller.rb
@@ -4,7 +4,8 @@ class FamilyMemoriesController < ApplicationController
   skip_after_action :verify_authorized
 
   def index
-    @memories = policy_scope(Memory, policy_scope_class: FamilyFeedMemoryPolicy::Scope)
+    @q = policy_scope(Memory, policy_scope_class: FamilyFeedMemoryPolicy::Scope).ransack(params[:q])
+    @memories = @q.result(distinct: true)
                   .with_attached_image
                   .includes(:user)
                   .order(created_at: :desc)

--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -5,7 +5,8 @@ class MemoriesController < ApplicationController
   skip_after_action :verify_authorized, only: :index
 
   def index
-    @my_memories = policy_scope(Memory).with_attached_image.order(created_at: :desc)
+    @q = policy_scope(Memory).ransack(params[:q])
+    @my_memories = @q.result(distinct: true).with_attached_image.order(created_at: :desc)
   end
 
   def new

--- a/app/controllers/public_memories_controller.rb
+++ b/app/controllers/public_memories_controller.rb
@@ -8,7 +8,8 @@ class PublicMemoriesController < ApplicationController
 
   # publishedのみ取得
   def index
-    @public_memories = Memory.publicly_available.with_attached_image.includes(:user).order(created_at: :desc)
+    @q = Memory.publicly_available.ransack(params[:q])
+    @public_memories = @q.result(distinct: true).with_attached_image.includes(:user).order(created_at: :desc)
   end
 
   def show

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -39,6 +39,17 @@ class Memory < ApplicationRecord
   # 公開投稿のみを取得するスコープ
   scope :publicly_available, -> { where(visibility: :published) }
 
+  # Ransack で検索可能なカラムの allow-list。明示しないカラムは検索クエリから弾かれる。
+  # 認可で守るべき情報(user_id, visibility 等)を意図せず晒さないため最小権限で運用する。
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[title description]
+  end
+
+  # 関連先検索は現状未使用のため空。将来タグ/こども絞り込みを追加するときに tags / children を許可する。
+  def self.ransackable_associations(_auth_object = nil)
+    %w[]
+  end
+
   # 定数
   # 画像はwebpで保存される - 注意!
   ACCEPT_CONTENT_TYPE = [ "image/png", "image/jpg", "image/jpeg", "image/webp" ].freeze

--- a/app/views/family_memories/index.html.erb
+++ b/app/views/family_memories/index.html.erb
@@ -35,9 +35,14 @@
     <%= render "shared/memory_search_form", q: @q, url: family_memories_path %>
 
     <% if @memories.blank? %>
-      <!-- 所属しているが投稿なし(または検索ヒットなし) -->
+      <%# 検索条件が空ではない時はヒット 0 件、それ以外は「投稿がまだない」と出し分け。
+          空欄送信(?q[...]=) は ransack が無視するので values の present? で判定する。 %>
       <div class="text-center text-base-content/60 mt-8">
-        <%= t('family_memories.index.empty_no_memories') %>
+        <% if params[:q]&.values&.any?(&:present?) %>
+          <%= t('family_memories.index.empty_no_search_results') %>
+        <% else %>
+          <%= t('family_memories.index.empty_no_memories') %>
+        <% end %>
       </div>
     <% else %>
       <!-- 家族フィード一覧（掲示板と同じカードスタイル） -->

--- a/app/views/family_memories/index.html.erb
+++ b/app/views/family_memories/index.html.erb
@@ -31,17 +31,21 @@
         <%= link_to t('family_memories.index.go_to_mypage'), mypage_path, class: "btn btn-primary btn-sm mt-2" %>
       </div>
     </div>
-  <% elsif @memories.blank? %>
-    <!-- 所属しているが投稿なし -->
-    <div class="text-center text-base-content/60 mt-8">
-      <%= t('family_memories.index.empty_no_memories') %>
-    </div>
   <% else %>
-    <!-- 家族フィード一覧（掲示板と同じカードスタイル） -->
-    <div class="masonry">
-      <%= render partial: "family_memories/memory",
-                 collection: @memories,
-                 as: :memory %>
-    </div>
+    <%= render "shared/memory_search_form", q: @q, url: family_memories_path %>
+
+    <% if @memories.blank? %>
+      <!-- 所属しているが投稿なし(または検索ヒットなし) -->
+      <div class="text-center text-base-content/60 mt-8">
+        <%= t('family_memories.index.empty_no_memories') %>
+      </div>
+    <% else %>
+      <!-- 家族フィード一覧（掲示板と同じカードスタイル） -->
+      <div class="masonry">
+        <%= render partial: "family_memories/memory",
+                   collection: @memories,
+                   as: :memory %>
+      </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/memories/index.html.erb
+++ b/app/views/memories/index.html.erb
@@ -19,6 +19,8 @@
     </div>
   </div>
 
+  <%= render "shared/memory_search_form", q: @q, url: memories_path %>
+
   <!-- ミニメモリ一覧 -->
   <% if @my_memories.present? %>
     <div class="masonry">

--- a/app/views/public_memories/index.html.erb
+++ b/app/views/public_memories/index.html.erb
@@ -19,6 +19,8 @@
     </div>
   </div>
 
+  <%= render "shared/memory_search_form", q: @q, url: public_memories_path %>
+
   <!-- 掲示板一覧 -->
   <% if @public_memories.present? %>
     <div class="masonry">

--- a/app/views/shared/_memory_search_form.html.erb
+++ b/app/views/shared/_memory_search_form.html.erb
@@ -1,0 +1,11 @@
+<%# Memory 一覧画面で再利用するキーワード検索フォーム。
+    title または description の部分一致(ILIKE)で絞り込む。
+    呼び出し側で q (Ransack::Search オブジェクト) と url (検索結果を表示する index path) を渡す。 %>
+<%= search_form_for q, url: url, method: :get, html: { class: "mb-4" } do |f| %>
+  <div class="flex gap-2">
+    <%= f.search_field :title_or_description_cont,
+          placeholder: t("memories.search.placeholder"),
+          class: "input input-bordered input-sm bg-base-200/50 focus:bg-base-100 focus:input-primary transition-all duration-200 w-full" %>
+    <%= f.submit t("memories.search.submit"), class: "btn btn-primary btn-sm" %>
+  </div>
+<% end %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -7,6 +7,7 @@ ja:
       empty_no_group_subtitle: 家族グループに参加すると、メンバーが共有したミニメモリーを見られます
       go_to_mypage: マイページへ
       empty_no_memories: 家族メンバーのミニメモリーはまだありません
+      empty_no_search_results: 検索条件に一致する投稿が見つかりませんでした
       posted_by: "%{name}さんの投稿"
       new_memory_fab_label: 新規投稿
   defaults:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -82,6 +82,9 @@ ja:
       tag_list_label: タグ (任意)
       tag_list_placeholder: "例: 石, お花屋さん, 帰り道"
       tag_list_hint: カンマ区切りで最大10個まで。30文字を超えるタグは反映されません
+    search:
+      placeholder: タイトル・本文で検索
+      submit: 検索
   public_memories:
     index:
       title: 掲示板


### PR DESCRIPTION
 ## 概要                                                                                                                                                                                    
                                                                                                                                                                                              
   - ransack を導入し、自分の投稿一覧 / 公開掲示板 / 家族グループ投稿の 3 つの index にキーワード検索を実装                                                                                   
   - 初回スコープは **タイトル・本文の部分一致** のみ。タグクリック検索とこども絞り込みは後続 PR で対応予定 
   
 ## 変更ファイル一覧                                                                                                                                                                        
                                                                                                                                                                                              
   | ファイル | 種別 | 変更理由 |                                                                                                                                                             
   |---------|------|---------|                                                                                                                                                               
   | Gemfile / Gemfile.lock | 追加 | ransack 導入 |                                                                                                                                           
   | app/models/memory.rb | 修正 | ransackable_attributes に title / description を許可 |                                                                                                     
   | app/views/shared/_memory_search_form.html.erb | 新規 | 3 画面で再利用する検索フォーム partial |
   | app/controllers/memories_controller.rb | 修正 | index に @q = policy_scope(Memory).ransack(params[:q]) を導入 |
   | app/controllers/public_memories_controller.rb | 修正 | index に @q = Memory.publicly_available.ransack(params[:q]) を導入 |
   | app/controllers/family_memories_controller.rb | 修正 | index に @q = policy_scope(...).ransack(params[:q]) を導入 |
   | app/views/memories/index.html.erb | 修正 | 検索フォーム partial を呼び出し |
   | app/views/public_memories/index.html.erb | 修正 | 同上 |
   | app/views/family_memories/index.html.erb | 修正 | 同上 + 家族グループ未所属時は検索バーを出さないよう構造変更 |
   | config/locales/views/ja.yml | 修正 | memories.search.placeholder / submit を追加 |

 ## 実装のポイント                                                                                                                                                                           
                                                                                                                                                                                              
  - **Pundit と Ransack の順序**: `policy_scope(Memory).ransack(params[:q])` の順で書き、認可された母集合に対してのみ検索を適用。逆順にすると他人の memory が検索結果に漏れるため厳守         
  - **ransackable_attributes で allow-list 管理**: Ransack 4 から明示的に許可した属性のみ検索可能。本 PR では `title` / `description` のみ許可、`ransackable_associations` 
  は空のままにすることで `user_id` / `visibility` 等の意図せぬ露出を防止                                                                                                                      
  - **`result(distinct: true)` を最初から使用**: タグ / こども絞り込みを後続 PR で追加した際の JOIN による重複表示を防ぐための先回り
  - **検索フォームを partial 化**: `shared/_memory_search_form.html.erb` で 3 画面共通化。`q` と `url` を local 引数で受け取る設計にし、呼び出し側から `memories_path` /                      
  `public_memories_path` / `family_memories_path` を渡す                                                                                                                                      
  - **`search_form_for` + `method: :get`**: 検索条件が URL クエリパラメータに乗るため、ブックマーク・URL 共有が可能                                                                           
  - **i18n 対応**: placeholder / submit ラベルを `config/locales/views/ja.yml` に追加 (`memories.search.placeholder` / `memories.search.submit`)                                              
  - **家族投稿画面の条件分岐**: 家族グループ未所属時は検索バーを表示せず、所属時のみ表示するよう view 構造を整理                                                                              
                                                                                                                                                                                              
  ## テスト計画                                                                                                                                                                               
                                                                                                                                                                                              
  - [x] `/memories` で検索 → 該当の memory のみ表示      
  - [x] `/memories` で空欄検索 → 全件表示に戻る                                                                                                                                               
  - [x] 検索後フォームに入力値が保持されている                                                                                                                                                
  - [x] `/public_memories` で同様の動作を確認                                                                                                                                                 
  - [x] `/family_memories` で同様の動作を確認                                                                                                                                                 
  - [x] 家族グループ未所属時は `/family_memories` に検索バーが表示されない                                                                                                                    
  - [x] 他人の memory が自分の `/memories` 検索結果に混ざらない（Pundit 認可スコープが維持されている）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * メモリ一覧にキーワード検索機能を追加しました。タイトルと説明文から条件に合致するメモリを検索できるようになりました。
  * ファミリーメモリ、個人メモリ、公開メモリの各一覧ページで検索フォームが利用可能になりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tantp-1111/mini_memory/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->