### PR TITLE
こども絞り込み、検索バーにタグ追加

### DIFF
--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -11,6 +11,13 @@ class Child < ApplicationRecord
     uuid
   end
 
+  # Memory#ransack(children_uuid_eq: ...) を通すために uuid のみ allow-list に追加。
+  # name は検索バーから逆引き偵察される懸念があるため許可しない。
+  # id / family_group_id も同様に許可しない。
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[uuid]
+  end
+
   private
 
   def birthday_not_in_future

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -45,9 +45,9 @@ class Memory < ApplicationRecord
     %w[title description]
   end
 
-  # tags 経由のタグクリック絞り込みを許可。children は次回 PR で追加予定。
+  # show ページからのタグ/こどもクリック絞り込みを許可。
   def self.ransackable_associations(_auth_object = nil)
-    %w[tags]
+    %w[tags children]
   end
 
   # 定数

--- a/app/views/family_memories/show.html.erb
+++ b/app/views/family_memories/show.html.erb
@@ -61,7 +61,9 @@
           </p>
           <div class="flex flex-wrap gap-2">
             <% @memory.children.each do |child| %>
-              <span class="badge badge-primary badge-lg"><%= child.name %></span>
+              <%= link_to child.name,
+                    family_memories_path(q: { children_uuid_eq: child.uuid }),
+                    class: "badge badge-primary badge-lg hover:badge-secondary transition-colors" %>
             <% end %>
           </div>
         </div>

--- a/app/views/memories/show.html.erb
+++ b/app/views/memories/show.html.erb
@@ -61,7 +61,9 @@
           </p>
           <div class="flex flex-wrap gap-2">
             <% @memory.children.each do |child| %>
-              <span class="badge badge-primary badge-lg"><%= child.name %></span>
+              <%= link_to child.name,
+                    memories_path(q: { children_uuid_eq: child.uuid }),
+                    class: "badge badge-primary badge-lg hover:badge-secondary transition-colors" %>
             <% end %>
           </div>
         </div>

--- a/app/views/shared/_memory_search_form.html.erb
+++ b/app/views/shared/_memory_search_form.html.erb
@@ -1,9 +1,9 @@
 <%# Memory 一覧画面で再利用するキーワード検索フォーム。
-    title または description の部分一致(ILIKE)で絞り込む。
+    title / description / tags.name の部分一致(ILIKE) OR で絞り込む。
     呼び出し側で q (Ransack::Search オブジェクト) と url (検索結果を表示する index path) を渡す。 %>
 <%= search_form_for q, url: url, method: :get, html: { class: "mb-4" } do |f| %>
   <div class="flex gap-2">
-    <%= f.search_field :title_or_description_cont,
+    <%= f.search_field :title_or_description_or_tags_name_cont,
           placeholder: t("memories.search.placeholder"),
           class: "input input-bordered input-sm bg-base-200/50 focus:bg-base-100 focus:input-primary transition-all duration-200 w-full" %>
     <%= f.submit t("memories.search.submit"), class: "btn btn-primary btn-sm" %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -84,7 +84,7 @@ ja:
       tag_list_placeholder: "例: 石, お花屋さん, 帰り道"
       tag_list_hint: カンマ区切りで最大10個まで。30文字を超えるタグは反映されません
     search:
-      placeholder: タイトル・本文で検索
+      placeholder: タイトル・本文・タグで検索
       submit: 検索
   public_memories:
     index:


### PR DESCRIPTION
 ## 概要                                                                                                                                                                                     
                                                                                                                                                                                              
  - 投稿詳細画面のこども badge をクリックすると、その child が紐づく memory のみに絞り込める機能を追加                                                                                        
  - 一覧の検索バーの対象に `tags.name` を追加し、タイトル / 本文 / タグ名で横断検索できるよう拡張                                                                                             
                                                                                                                                                                                        
  ## 変更ファイル一覧                                                                                                                                                                         
                                                                                                                                                                                            
  | ファイル | 種別 | 変更理由 |                                                                                                                                                              
  |---------|------|---------|                                                                                                                                                              
  | app/models/memory.rb | 修正 | ransackable_associations に children を追加 |                                                                                                               
  | app/models/child.rb | 修正 | ransackable_attributes に uuid を追加（name / id / family_group_id は許可しない） |
  | app/views/memories/show.html.erb | 修正 | こども badge を link_to に変換し、memories_path(q: { children_uuid_eq: }) に遷移 |                                                              
  | app/views/family_memories/show.html.erb | 修正 | 同上、family_memories_path 経由 |                                                                                                        
  | app/views/shared/_memory_search_form.html.erb | 修正 | predicate を title_or_description_or_tags_name_cont に拡張 |                                                                       
  | config/locales/views/ja.yml | 修正 | placeholder 文言を「タイトル・本文・タグで検索」に更新 |                                                                                             
                                                                                                                                                                                              
  ## 実装のポイント                                                                                                                                                                           
                                                                                                                    
  - **こども絞り込みは UUID 一致** (`children_uuid_eq`): Child は family_group スコープなので「同じ太郎ちゃん」を一意に指すには uuid が必要。アプリの URL 規約とも整合                        
  - **`Child.ransackable_attributes` を `uuid` のみに**: `name` を許可すると `/public_memories?q[children_name_cont]=太郎` のような偵察 URL が成立しうるため除外。`id` / `family_group_id` 
  も同様に内部 ID 漏洩を防ぐ                                                                                                                                                                  
  - **`public_memories/show` ではこども情報を表示しない既存方針を維持**: 同じ理由でこども絞り込み UI は memories/show と family_memories/show のみ
  - **検索バーへのタグ追加は全 3 画面で安全**: タグ名は show ページで既に公開表示している情報なので、`/public_memories` でも検索条件に含めて問題なし                                          
  - **複合検索可能**: 検索バー (`tags_name_cont`) とタグ badge click (`tags_name_eq`)、こども badge click (`children_uuid_eq`) は別 predicate なので、URL クエリに同時に乗ると ransackのデフォルトで AND される                                                                                                                                                                  
  - **Pundit ↔ Ransack の順序を維持**: `policy_scope(...).ransack(...)` の順で認可済み母集合に対してのみ検索が走る                                                                            
                                                                                                                                                                                              
  ## テスト計画                                                                                                     
                                                                                                                                                                                              
  - [x] `/memories/:uuid` でこども badge クリック → `/memories?q[children_uuid_eq]=...` に遷移、自分の memory のうちその child が紐づくものだけ表示
  - [x] `/family_memories/:uuid` でこども badge クリック → `/family_memories?q[children_uuid_eq]=...` に遷移、家族メンバー横断で該当 memory のみ表示                                          
  - [x] `/memories` 検索バーで「保育園」を検索 → タイトル / 本文 / タグ名のいずれかが「保育園」を含む memory が表示                                                                           
  - [x] `/family_memories` / `/public_memories` でも検索バーの挙動が同様                                                                                                                      
  - [x] 他家族グループの child uuid を URL に渡しても 0 件（Pundit + Memory バリデーションで二重防御）                                                                                        
  - [x] `/public_memories?q[children_uuid_eq]=...` / `?q[children_name_cont]=...` を URL クラフトしてもこども絞り込みは効かない（public ではこども情報非表示の方針）                          

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **子どもによる絞り込み機能**
  * 家族アルバムと思い出一覧で、子どもの名前をクリックするとその子ども関連の思い出のみを表示できるようになりました。

* **タグ検索の拡張**
  * キーワード検索でタイトル・本文に加え、タグでも検索できるようになりました。検索フォームのラベルを「タイトル・本文・タグで検索」に更新しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->