### PR TITLE
一覧画面にこどもチェックボックス絞り込みを追加、検索フォームレイアウト改善

### DIFF
--- a/app/controllers/family_memories_controller.rb
+++ b/app/controllers/family_memories_controller.rb
@@ -10,6 +10,7 @@ class FamilyMemoriesController < ApplicationController
                   .includes(:user)
                   .order(created_at: :desc)
     @has_family_group = current_user.family_groups.exists?
+    @available_children = policy_scope(Child).order(:birthday)
   end
 
   def show

--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -7,6 +7,7 @@ class MemoriesController < ApplicationController
   def index
     @q = policy_scope(Memory).ransack(params[:q])
     @my_memories = @q.result(distinct: true).with_attached_image.order(created_at: :desc)
+    @available_children = policy_scope(Child).order(:birthday)
   end
 
   def new

--- a/app/views/family_memories/index.html.erb
+++ b/app/views/family_memories/index.html.erb
@@ -32,7 +32,7 @@
       </div>
     </div>
   <% else %>
-    <%= render "shared/memory_search_form", q: @q, url: family_memories_path %>
+    <%= render "shared/memory_search_form", q: @q, url: family_memories_path, children: @available_children %>
 
     <% if @memories.blank? %>
       <%# 検索条件が空ではない時はヒット 0 件、それ以外は「投稿がまだない」と出し分け。

--- a/app/views/memories/index.html.erb
+++ b/app/views/memories/index.html.erb
@@ -19,7 +19,7 @@
     </div>
   </div>
 
-  <%= render "shared/memory_search_form", q: @q, url: memories_path %>
+  <%= render "shared/memory_search_form", q: @q, url: memories_path, children: @available_children %>
 
   <!-- ミニメモリ一覧 -->
   <% if @my_memories.present? %>

--- a/app/views/shared/_memory_search_form.html.erb
+++ b/app/views/shared/_memory_search_form.html.erb
@@ -13,20 +13,25 @@
       「これは検索条件の集合体」と視覚的に伝える %>
   <div class="bg-base-200/50 border border-base-300 rounded-lg p-3 flex flex-col gap-3">
     <% if children.any? %>
-      <%# こども絞り込み (標準 checkbox - 「フォームの選択肢」とひと目で分かるよう
-          ボタン風スタイルではなく chip 風 form コントロールにする) %>
-      <% selected_child_uuids = (params.dig(:q, :children_uuid_in) || []) %>
-      <div class="flex flex-wrap gap-x-4 gap-y-2">
-        <% children.each do |child| %>
-          <label class="flex items-center gap-2 cursor-pointer">
-            <input type="checkbox"
-                   name="q[children_uuid_in][]"
-                   value="<%= child.uuid %>"
-                   <%= "checked" if selected_child_uuids.include?(child.uuid) %>
-                   class="checkbox checkbox-primary checkbox-sm" />
-            <span class="text-sm"><%= child.name %></span>
-          </label>
-        <% end %>
+      <%# 絞り込み検索ラベル + こども チェックボックス
+          (標準 checkbox を使い「フォームの選択肢」とひと目で分かるようにする) %>
+      <div>
+        <p class="text-xs font-bold tracking-widest text-base-content/60 mb-2">
+          <%= t("memories.search.filter_label") %>
+        </p>
+        <% selected_child_uuids = (params.dig(:q, :children_uuid_in) || []) %>
+        <div class="flex flex-wrap gap-x-4 gap-y-2">
+          <% children.each do |child| %>
+            <label class="flex items-center gap-2 cursor-pointer">
+              <input type="checkbox"
+                     name="q[children_uuid_in][]"
+                     value="<%= child.uuid %>"
+                     <%= "checked" if selected_child_uuids.include?(child.uuid) %>
+                     class="checkbox checkbox-primary checkbox-sm" />
+              <span class="text-sm"><%= child.name %></span>
+            </label>
+          <% end %>
+        </div>
       </div>
     <% end %>
 

--- a/app/views/shared/_memory_search_form.html.erb
+++ b/app/views/shared/_memory_search_form.html.erb
@@ -1,9 +1,35 @@
-<%# Memory 一覧画面で再利用するキーワード検索フォーム。
-    title / description / tags.name の部分一致(ILIKE) OR で絞り込む。
-    呼び出し側で q (Ransack::Search オブジェクト) と url (検索結果を表示する index path) を渡す。 %>
+<%# Memory 一覧画面で再利用するキーワード検索 + こども絞り込みフォーム。
+    title / description / tags.name の部分一致(ILIKE) OR で絞り込み、
+    こどもチェックボックスで children_uuid_in の AND 条件を追加する。
+    呼び出し側で以下を渡す:
+      q        : Ransack::Search オブジェクト
+      url      : 検索結果を表示する index path
+      children : (省略可) 家族グループ所属こどもの ActiveRecord::Relation。
+                 未指定 / 空なら toggle section は非表示
+                 (/public_memories ではこども情報を扱わないので不要) %>
+<% children = local_assigns[:children] || [] %>
 <%= search_form_for q, url: url, method: :get, html: { class: "mb-4" } do |f| %>
-  <%# フォーム全体をカードで括って「検索条件の集合体」と視覚的に伝える %>
+  <%# こども選択 + キーワード入力 + 検索ボタンを 1 つのカードにまとめて
+      「これは検索条件の集合体」と視覚的に伝える %>
   <div class="bg-base-200/50 border border-base-300 rounded-lg p-3 flex flex-col gap-3">
+    <% if children.any? %>
+      <%# こども絞り込み (標準 checkbox - 「フォームの選択肢」とひと目で分かるよう
+          ボタン風スタイルではなく chip 風 form コントロールにする) %>
+      <% selected_child_uuids = (params.dig(:q, :children_uuid_in) || []) %>
+      <div class="flex flex-wrap gap-x-4 gap-y-2">
+        <% children.each do |child| %>
+          <label class="flex items-center gap-2 cursor-pointer">
+            <input type="checkbox"
+                   name="q[children_uuid_in][]"
+                   value="<%= child.uuid %>"
+                   <%= "checked" if selected_child_uuids.include?(child.uuid) %>
+                   class="checkbox checkbox-primary checkbox-sm" />
+            <span class="text-sm"><%= child.name %></span>
+          </label>
+        <% end %>
+      </div>
+    <% end %>
+
     <%# キーワード入力 %>
     <%= f.search_field :title_or_description_or_tags_name_cont,
           placeholder: t("memories.search.placeholder"),

--- a/app/views/shared/_memory_search_form.html.erb
+++ b/app/views/shared/_memory_search_form.html.erb
@@ -2,10 +2,16 @@
     title / description / tags.name の部分一致(ILIKE) OR で絞り込む。
     呼び出し側で q (Ransack::Search オブジェクト) と url (検索結果を表示する index path) を渡す。 %>
 <%= search_form_for q, url: url, method: :get, html: { class: "mb-4" } do |f| %>
-  <div class="flex gap-2">
+  <%# フォーム全体をカードで括って「検索条件の集合体」と視覚的に伝える %>
+  <div class="bg-base-200/50 border border-base-300 rounded-lg p-3 flex flex-col gap-3">
+    <%# キーワード入力 %>
     <%= f.search_field :title_or_description_or_tags_name_cont,
           placeholder: t("memories.search.placeholder"),
-          class: "input input-bordered input-sm bg-base-200/50 focus:bg-base-100 focus:input-primary transition-all duration-200 w-full" %>
-    <%= f.submit t("memories.search.submit"), class: "btn btn-primary btn-sm" %>
+          class: "input input-bordered input-sm bg-base-100 focus:input-primary transition-all duration-200 w-full" %>
+
+    <%# 検索ボタンは下段に。右寄せでフォームの締めくくり感を出す %>
+    <div class="flex justify-end">
+      <%= f.submit t("memories.search.submit"), class: "btn btn-primary btn-sm px-6" %>
+    </div>
   </div>
 <% end %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -86,6 +86,7 @@ ja:
     search:
       placeholder: タイトル・本文・タグで検索
       submit: 検索
+      filter_label: 絞り込み検索
   public_memories:
     index:
       title: 掲示板


### PR DESCRIPTION
 ## 概要                                                                                                                                                                                                                                                                                                
  - memories / family_memories の index に **こどもチェックボックスで絞り込む** UI を追加                                                                                                     
  - 検索フォーム全体をカード化し、検索ボタンを下段に移動して整理
  - 「絞り込み検索」セクションラベルを設置し、こどもチェックボックス群の役割を一目で伝える    

## 変更ファイル一覧
                                                                                                                                                                                              
  | ファイル | 種別 | 変更理由 |                                                                                    
  |---------|------|---------|                                 
  | app/controllers/memories_controller.rb | 修正 | index で `@available_children = policy_scope(Child).order(:birthday)` をセット |                                                          
  | app/controllers/family_memories_controller.rb | 修正 | 同上 |                                                                                                                             
  | app/views/memories/index.html.erb | 修正 | partial に `children: @available_children` を渡す |                                                                                            
  | app/views/family_memories/index.html.erb | 修正 | 同上 |                                                                                                                                  
  | app/views/shared/_memory_search_form.html.erb | 修正 | カード化 + 検索ボタン下段配置 + こどもチェックボックス group + 「絞り込み検索」ラベル |                                            
  | config/locales/views/ja.yml | 修正 | `memories.search.filter_label` キー追加 |                                                                                                            
                                                                                                                                                                                              
  ## 実装のポイント                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  - **既存機能との両立**: キーワード検索 (`title_or_description_or_tags_name_cont`) / タグ badge クリック (`tags_name_eq`) / こども badge クリック (`children_uuid_eq`)                       
  と組み合わせ可能（ransack のデフォルト AND）                                                                                                                                                
                                                                                                                                                                                              
  ## テスト計画                                                                                                                                                                               
                                                                                                                    
  - [ ] `/memories` に「絞り込み検索」ラベル + こどもチェックボックス + キーワード欄 + 検索ボタンがカード内に縦に並んで表示される                                                             
  - [ ] こどもチェックボックスを 1 つ check → 検索ボタン → 該当 child が紐づく自分の memory のみ表示
  - [ ] 複数 check → 検索 → OR で絞り込まれる                                                                                                                                                 
  - [ ] 何も check せず検索 → 全件表示                                                                                                                                                        
  - [ ] キーワード欄入力 + こども check + 検索 → 両条件 AND で絞り込まれる                                                                                                                    
  - [ ] `/family_memories` でも同じ挙動（FamilyFeedScope 経由で家族メンバー横断）                                                                                                             
  - [ ] `/public_memories` ではこどもチェックボックス section が表示されない（partial に children を渡していないため）                                                                        
  - [ ] 家族グループ未所属 / こども 0 人のユーザー → `@available_children` が空 → section 非表示                                                                                              
  - [ ] 既存の show ページのこども / タグ badge クリックは従来どおり動作

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * メモリー検索フォームに子どもによる絞り込み機能を追加しました。検索時に特定の子どもを選択してメモリーをフィルタリングできるようになります。

* **改善**
  * メモリー検索フォームのレイアウトを改善し、より視認性の高いカード構造に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->