### PR TITLE
スマホUI/ドロワー/マイページの軽微な調整

### DIFF
--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -42,6 +42,40 @@ document.addEventListener('change', (e) => {
     renderPreview(file);
 });
 
+// アバター画像プレビューを生成して avatar-preview コンテナに差し替える
+function renderAvatarPreview(file) {
+    const container = document.getElementById('avatar-preview');
+    if (!container) return;
+
+    revokeCurrentObjectUrl();
+    currentObjectUrl = window.URL.createObjectURL(file);
+
+    container.innerHTML = '';
+
+    const avatarDiv = document.createElement('div');
+    avatarDiv.className = 'avatar';
+    avatarDiv.dataset.jsPreview = 'true';
+
+    const innerDiv = document.createElement('div');
+    innerDiv.className = 'w-20 h-20 rounded-full overflow-hidden';
+
+    const img = document.createElement('img');
+    img.src = currentObjectUrl;
+    img.alt = 'avatar preview';
+    img.className = 'w-full h-full object-cover';
+
+    innerDiv.appendChild(img);
+    avatarDiv.appendChild(innerDiv);
+    container.appendChild(avatarDiv);
+}
+
+document.addEventListener('change', (e) => {
+    if (e.target.id !== 'user_avatar') return;
+    const file = e.target.files[0];
+    if (!file) return;
+    renderAvatarPreview(file);
+});
+
 // バックボタンキャッシュの clean up
 // ERB が描画した既存画像は残し、JS で追加した preview のみクリアする
 // 残っている object URL もここで revoke する

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -47,6 +47,11 @@ function renderAvatarPreview(file) {
     const container = document.getElementById('avatar-preview');
     if (!container) return;
 
+    // Turbo back キャッシュ復帰時に元の表示（添付済み画像 or placeholder）を戻せるよう原 HTML を保持
+    if (!container.dataset.originalHtml) {
+        container.dataset.originalHtml = container.innerHTML;
+    }
+
     revokeCurrentObjectUrl();
     currentObjectUrl = window.URL.createObjectURL(file);
 
@@ -90,5 +95,12 @@ document.addEventListener('turbo:before-cache', () => {
     if (fileNameEl) {
         fileNameEl.textContent = '';
         fileNameEl.classList.add('hidden');
+    }
+
+    // アバタープレビューは原 HTML を退避していれば戻す
+    const avatarPreview = document.getElementById('avatar-preview');
+    if (avatarPreview?.dataset.originalHtml) {
+        avatarPreview.innerHTML = avatarPreview.dataset.originalHtml;
+        delete avatarPreview.dataset.originalHtml;
     }
 });

--- a/app/views/dashboard/top.html.erb
+++ b/app/views/dashboard/top.html.erb
@@ -76,7 +76,7 @@
             </svg>
           </div>
           <div>
-            <h2 class="card-title text-base">家族のミニメモリ</h2>
+            <h2 class="card-title text-base">家族メモリ</h2>
             <p class="text-sm text-base-content/60 mt-1">家族メンバーが共有したミニメモリーを見られます。</p>
           </div>
         </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -22,7 +22,7 @@
         <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, multipart: true }) do |f| %>
           <%= render "shared/error_messages", object: resource %>
 
-          <div class="flex flex-col items-center gap-2">
+          <div id="avatar-preview" class="flex flex-col items-center gap-2">
             <% if resource.avatar.attached? %>
               <div class="avatar">
                 <div class="w-20 h-20 rounded-full overflow-hidden">

--- a/app/views/family_memories/index.html.erb
+++ b/app/views/family_memories/index.html.erb
@@ -1,6 +1,6 @@
 <div class="max-w-6xl mx-auto px-4 pt-6 pb-24">
 
-  <!-- 背景装飾（家族のミニメモリ: violet + sky - プライベート / 落ち着き） -->
+  <!-- 背景装飾（家族メモリ: violet + sky - プライベート / 落ち着き） -->
   <div class="fixed inset-0 overflow-hidden pointer-events-none">
     <div class="absolute -top-24 -right-24 w-96 h-96 rounded-full opacity-20 bg-violet-400 blur-3xl"></div>
     <div class="absolute -bottom-24 -left-24 w-96 h-96 rounded-full opacity-20 bg-sky-300 blur-3xl"></div>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -19,33 +19,28 @@
     </div>
 
     <div class="card bg-base-100 shadow-2xl border border-base-200">
-      <div class="card-body p-6 gap-4">
-      <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60"><%= t('mypage.avatar') %></span>
-        <div class="flex flex-col items-center gap-3">
+      <div class="card-body p-4">
+        <div class="flex items-center gap-4">
           <% if @user.avatar.attached? %>
-            <div class="avatar">
-              <div class="w-20 h-20 rounded-full overflow-hidden">
+            <div class="avatar shrink-0">
+              <div class="w-16 h-16 rounded-full overflow-hidden">
                 <%= image_tag @user.avatar, class: "w-full h-full object-cover", alt: @user.name %>
               </div>
             </div>
           <% else %>
-            <div class="avatar placeholder">
-              <div class="bg-neutral text-neutral-content rounded-full w-20 h-20 flex items-center justify-center">
-                <span class="text-2xl font-bold"><%= @user.name&.slice(0, 1) %></span>
+            <div class="avatar placeholder shrink-0">
+              <div class="bg-neutral text-neutral-content rounded-full w-16 h-16 flex items-center justify-center">
+                <span class="text-xl font-bold"><%= @user.name&.slice(0, 1) %></span>
               </div>
             </div>
           <% end %>
-        </div>
 
-        <div class="form-control gap-1">
-          <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60"><%= t('mypage.user_name') %></span>
-          <div class="w-full flex items-center justify-center">
-            <span class="text-lg font-medium text-base-content"><%= @user.name %></span>
+          <div class="flex-1 min-w-0">
+            <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60"><%= t('mypage.user_name') %></span>
+            <p class="text-lg font-medium text-base-content truncate"><%= @user.name %></p>
           </div>
-        </div>
 
-        <div class="flex justify-center pt-1 pb-2">
-          <%= link_to t('helpers.submit.edit'), edit_user_registration_path, class: "btn btn-primary btn-sm px-6" %>
+          <%= link_to t('helpers.submit.edit'), edit_user_registration_path, class: "btn btn-primary btn-sm shrink-0" %>
         </div>
       </div>
     </div>

--- a/app/views/shared/_drawer_menu.html.erb
+++ b/app/views/shared/_drawer_menu.html.erb
@@ -19,6 +19,7 @@
         <summary><%= t('drawer.summary.family_mini_memory') %></summary>
         <ul>
           <li><%= link_to t('drawer.list.family_memory_index'), family_memories_path %></li>
+          <li><%= link_to t('drawer.list.family_group_settings'), mypage_path %></li>
         </ul>
       </details>
     </li>

--- a/app/views/shared/_drawer_menu.html.erb
+++ b/app/views/shared/_drawer_menu.html.erb
@@ -67,7 +67,7 @@
     </li>
   <% end %>
 
-  <li class="mt-auto text-center text-sm opacity-60 py-4">
-    © Mini memory
+  <li class="mt-auto text-center text-xs opacity-50 py-4">
+    © 2026 minimemory
   </li>
 </ul>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,6 +1,6 @@
 <% if user_signed_in? %>
-  <footer class="fixed bottom-0 w-full px-4 py-4">
-    <div class="dock bg-base-100 text-neutral dock-xs md:dock-xl">
+  <footer class="fixed bottom-0 w-full">
+    <div class="dock bg-base-100 text-neutral dock-md md:dock-xl">
       <%# ホームボタン %>
       <%= link_to root_path, class: "flex flex-col items-center justify-center text-xs #{active_if("dashboard")}" do %>
         <span class="text-xl">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -193,6 +193,7 @@ ja:
       memory_index: ミニメモリ一覧
       enjoy: 楽しむ
       family_memory_index: 家族メモリ一覧
+      family_group_settings: 家族グループ設定
       board: 掲示板
       mypage: マイページ
       logout: ログアウト

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,7 +1,7 @@
 ja:
   family_memories:
     index:
-      title: 家族のミニメモリ
+      title: 家族メモリ
       subtitle: 家族メンバーが共有したミニメモリーを一覧で見られます
       empty_no_group_title: 家族グループに所属していません
       empty_no_group_subtitle: 家族グループに参加すると、メンバーが共有したミニメモリーを見られます
@@ -178,13 +178,13 @@ ja:
     home: ホーム
     mini_memory: ミニメモリ
     new_memory: 新規投稿
-    family_memory: 家族のミニメモリ
+    family_memory: 家族メモリ
     board: 掲示板
     enjoy: 楽しむ
   drawer:
     summary:
       mini_memory: 私のミニメモリ
-      family_mini_memory: 家族のミニメモリ
+      family_mini_memory: 家族メモリ
       everyone_mini_memory: みんなのミニメモリ
       account: アカウント
       others: その他
@@ -192,7 +192,7 @@ ja:
       create_memory: 新規投稿
       memory_index: ミニメモリ一覧
       enjoy: 楽しむ
-      family_memory_index: 家族のミニメモリ一覧
+      family_memory_index: 家族メモリ一覧
       board: 掲示板
       mypage: マイページ
       logout: ログアウト

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
     resources :reactions, only: %i[create destroy], param: :reaction_type
   end
 
-  # 家族のミニメモリ - 家族メンバー横断のフィード（unlisted + published）。
+  # 家族メモリ - 家族メンバー横断のフィード（unlisted + published）。
   # show を独立させることで、タグクリック等の遷移先文脈を URL prefix で表現する。
   resources :family_memories, param: :uuid, only: %i[index show]
 


### PR DESCRIPTION
## 概要                                                                                                                                                                                                                                       
  スマホ表示・ドロワーメニュー・マイページの細かいUIを調整。
## 変更ファイル一覧                                                                                                                                                                                                                           
  | ファイル | 種別 | 変更理由 |                                                                                                                                                                                                                
  |---------|------|---------|                                                                                                                                                                                                                  
  | app/views/shared/_footer.html.erb | 変更 | フッターの px-4 py-4 削除 + dock-xs→dock-md でタップ領域を拡大 |                                                                                                                             
  | app/views/dashboard/top.html.erb | 変更 | 「家族のミニメモリ」→「家族メモリ」表記変更 |                                                                                                                                                 
  | app/views/family_memories/index.html.erb | 変更 | 同上（背景装飾のコメント） |                                                                                                                                                          
  | config/locales/views/ja.yml | 変更 | 「家族メモリ」表記統一 + 「家族グループ設定」ラベル追加 |                                                                                                                                          
  | config/routes.rb | 変更 | コメント文言の統一 |                                                                                                                                                                                          
  | app/views/shared/_drawer_menu.html.erb | 変更 | コピーライト整形 + 家族メモリ配下に「家族グループ設定」リンク追加 |                                                                                                                     
  | app/views/mypages/show.html.erb | 変更 | プロフィールカードを横並びにして縦幅を圧縮 |                                                                                                                                                   
  | app/views/devise/registrations/edit.html.erb | 変更 | アバター画像コンテナに id 付与（preview ターゲット） |                                                                                                                            
  | app/javascript/preview.js | 変更 | user_avatar 入力に対応するプレビュー描画ハンドラを追加 |                                                                                                                                             
                                                                                                                                                                                                                                                
  ## 実装のポイント                                                                                                                                                                                                                             
  - **フッター:** `px-4 py-4` を削除して dock を画面端まで広げ、`dock-xs` を `dock-md` に上げてアイコン・タップ領域を拡大                                                                                                                       
  - **「家族メモリ」表記:** スマホでバランス悪い「家族のミニメモリ」を「家族メモリ」に短縮（ビュー / i18n / ルーティングコメント横断で一括変更）                                                                                                
  - **コピーライト:** `© Mini memory` → `© 2026 minimemory` で年号と表記揺れを整え、`text-xs opacity-50` で控えめに                                                                                                                             
  - **ドロワー導線:** 「家族メモリ」配下に「家族グループ設定」を追加し、マイページの家族グループ管理セクションに直接遷移できるように                                                                                                            
  - **プロフィールカード:** アバターとユーザー名を横並びにし、編集ボタンを右端へ。冗長な「アバター画像」ラベルを削除して縦幅圧縮                                                                                                                
  - **アバタープレビュー:** 既存 `preview.js` の event delegation を流用して `user_avatar` 入力に対応、ファイル選択時に丸型でプレビュー表示                                                                                                     
                                                                                                                                                                                                                                                


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * プロフィール画像アップロード時のプレビューを追加しました（選択時に即時表示、ページキャッシュ復元時に元表示へ戻る処理を含む）。

* **UI/UX改善**
  * 表記を「家族メモリ」に統一しました。
  * マイページのアカウント情報カードのレイアウトを改善しました。
  * ドロワーメニューに「家族グループ設定」リンクを追加しました。
  * フッターのコピーライト表記と表示サイズを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->