### PR TITLE
アプリ全体のテーマカラーを変更

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -2,3 +2,14 @@
 @plugin "daisyui" {
   themes: autumn --default, night;
 }
+
+/* autumn テーマの赤系をロゴカラー（黄緑・黄）で上書き
+   - primary（暗い赤）   → #87B63B（ロゴの葉/茎の黄緑）
+   - secondary（明るい赤）→ #FFAA22（ロゴの実の黄）
+   - content はコントラスト確保のため明色背景にダーク文字 */
+[data-theme="autumn"] {
+  --color-primary: #87B63B;
+  --color-primary-content: #1f2937;
+  --color-secondary: #FFAA22;
+  --color-secondary-content: #1f2937;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html data-theme="autumn">
   <head>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-SBFNVWNS7W"></script>


### PR DESCRIPTION
 ## 概要                                                    
  daisyUI の `autumn` テーマをベースに、`primary` と `secondary` をロゴから抽出したカラーで上書きする。アプリ全体の色味をロゴ（黄緑+黄）に統一し、ブランド一貫性を向上させる。
                                                                                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                
  ## 変更ファイル一覧                                        
  | ファイル | 種別 | 変更理由 |                                                                                                                                                                                                                
  |---------|------|---------|                                                                                                                                                                                                                  
  | app/assets/tailwind/application.css | 変更 | autumn テーマの primary/secondary を CSS 変数で上書き |
  | app/views/layouts/application.html.erb | 変更 | `<html>` に `data-theme="autumn"` を明示し、上書きセレクタを有効化 |                                                                                                                    
             

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * 秋テーマを追加しました。アプリケーション全体のテーマカラーを秋色パレットで更新することで、より洗練された統一感のあるビジュアルデザインと優れたコントラストを実現し、快適な利用体験をお届けします。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->