### PR TITLE
ruby-vips gem を Gemfile に明示追加して画像処理の LoadError を解消

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,10 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 2.0"
 
+# ruby-vips - image_processing の Vips バックエンドに必要
+# image_processing 2.x から runtime 依存ではなくなったため明示
+gem "ruby-vips", "~> 2.0"
+
 # Tailwind CSS - ユーティリティファーストなCSSフレームワーク
 gem "tailwindcss-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -385,6 +385,9 @@ GEM
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.3.0)
+      ffi (~> 1.12)
+      logger
     rubyzip (3.2.2)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -493,6 +496,7 @@ DEPENDENCIES
   rails_admin (~> 3.0)
   ransack
   rubocop-rails-omakase
+  ruby-vips (~> 2.0)
   sassc-rails
   selenium-webdriver
   sprockets-rails


### PR DESCRIPTION
 ## 概要
  - ミニメモリ投稿時に `ImageProcessing::Vips requires the ruby-vips gem` の LoadError で画像保存できない不具合を修正
  - `ruby-vips ~> 2.0` を Gemfile に明示追加

  ## 変更ファイル一覧
  | ファイル | 種別 | 変更理由 |
  |---------|------|---------|
  | `Gemfile` | 修正 | `ruby-vips` を runtime 依存として明示 |
  | `Gemfile.lock` | 修正 | `bundle install` で `ruby-vips 2.3.0` を追加 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 画像処理機能の依存ライブラリを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->