### PR TITLE
sassc-rails を dartsass-sprockets に置換して本番 precompile を復旧

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,8 +96,11 @@ gem "ransack"
 # rails_admin - 管理画面（運営者向け CRUD UI）
 gem "rails_admin", "~> 3.0"
 
-# sassc-rails - rails_admin のスタイル（SCSS）コンパイル用
-gem "sassc-rails"
+# dartsass-sprockets - rails_admin のスタイル（SCSS）コンパイル用
+# sassc-rails (libsass) は 2020 年からメンテ停止しており、
+# CSS Color Level 4 構文（rgb(from ...) など）で precompile が失敗するため、
+# Dart Sass (公式実装) ベースの dartsass-sprockets に置き換える
+gem "dartsass-sprockets"
 
 group :development, :test do
   # debug - デバッグツール

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,12 @@ GEM
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
     csv (3.3.5)
+    dartsass-sprockets (3.2.1)
+      railties (>= 4.0.0)
+      sassc-embedded (~> 1.80.1)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -152,6 +158,27 @@ GEM
     ffi (1.17.4-x86_64-linux-musl)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    google-protobuf (4.35.0)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-aarch64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-aarch64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-arm64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-x86_64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-x86_64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-x86_64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
     hashie (5.1.0)
       logger
     i18n (1.14.8)
@@ -389,14 +416,24 @@ GEM
       ffi (~> 1.12)
       logger
     rubyzip (3.2.2)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
+    sass-embedded (1.100.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    sassc-embedded (1.80.8)
+      sass-embedded (~> 1.80)
     securerandom (0.4.1)
     selenium-webdriver (4.40.0)
       base64 (~> 0.2)
@@ -476,6 +513,7 @@ DEPENDENCIES
   capybara
   cloudinary
   cssbundling-rails
+  dartsass-sprockets
   debug
   devise
   devise-i18n
@@ -497,7 +535,6 @@ DEPENDENCIES
   ransack
   rubocop-rails-omakase
   ruby-vips (~> 2.0)
-  sassc-rails
   selenium-webdriver
   sprockets-rails
   stimulus-rails


### PR DESCRIPTION
## 概要
  - 本番 `assets:precompile` が `SassC::SyntaxError: Function rgb is missing argument $green` で失敗していた問題を解消
  - メンテ停止中の `sassc-rails`（libsass）を、Dart Sass ベースの `dartsass-sprockets` に置換


  ## 変更ファイル一覧
  | ファイル | 種別 | 変更理由 |
  |---------|------|---------|
  | `Gemfile` | 修正 | `sassc-rails` を削除し `dartsass-sprockets` を追加 |
  | `Gemfile.lock` | 修正 | `bundle install` で sassc → dartsass-sprockets 3.2.1 / sassc-embedded 1.80.x に切替 |

  ## ポイント
  ### 根本原因
  - Tailwind 4 / daisyUI が `@supports` 内で **CSS Color Level 4 の relative color syntax**（例: `rgb(from red r g b)`）を吐き出す
  - libsass (sassc) は 2020 年からメンテ停止しており、近代 CSS 構文を `rgb()` Sass 関数呼び出しと誤解釈
  - `sassc-rails` は `text/css` 全般のポストプロセッサとして Sprockets に登録されるため、Tailwind がビルドした `app/assets/builds/application.css` まで SassC が触ってしまい precompile が落ちていた


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * スタイルコンパイルの依存関係を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->