### PR TITLE
Github CIにRSpec の実行ステップを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,12 @@ jobs:
           # REDIS_URL: redis://localhost:6379/0
         run: bin/rails db:test:prepare test test:system
 
+      - name: Run RSpec
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432
+        run: bundle exec rspec
+
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v6
         if: failure()


### PR DESCRIPTION
## 概要
  - PR #267 で導入した RSpec が CI で実行されていなかった問題を解消
  - 既存の Minitest（`bin/rails test test:system`）はそのまま残し、 `bundle exec rspec` を追加実行

  ## 変更ファイル一覧
  | ファイル | 種別 | 変更理由 |
  |---------|------|---------|
  | `.github/workflows/ci.yml` | 修正 | test ジョブに `Run RSpec` ステップを追加 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CD パイプラインのテスト実行方法を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->