### PR TITLE
Memory のカスタムバリデーションとタグ同期 (after_save) の spec を追加

### DIFF
--- a/spec/factories/children.rb
+++ b/spec/factories/children.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :child do
+    family_group
+    name { "テストこども" }
+  end
+end

--- a/spec/factories/family_groups.rb
+++ b/spec/factories/family_groups.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :family_group do
+    name { "テスト家族" }
+  end
+end

--- a/spec/factories/user_family_groups.rb
+++ b/spec/factories/user_family_groups.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user_family_group do
+    user
+    family_group
+    role { :member }
+  end
+end

--- a/spec/models/memory_spec.rb
+++ b/spec/models/memory_spec.rb
@@ -80,4 +80,77 @@ RSpec.describe Memory, type: :model do
       expect(memory.to_param).to eq(memory.uuid)
     end
   end
+
+  describe "image の content_type バリデーション" do
+    let(:memory) { build(:memory) }
+
+    it "factory デフォルトの PNG は valid" do
+      expect(memory).to be_valid
+    end
+
+    it "JPEG / WEBP も valid" do
+      %w[image/jpeg image/webp].each do |type|
+        m = build(:memory)
+        m.image.attach(
+          io: Rails.root.join("spec/fixtures/files/test_image_200x200.png").open,
+          filename: "test.#{type.split('/').last}",
+          content_type: type
+        )
+        expect(m).to be_valid, "#{type} should be valid"
+      end
+    end
+
+    it "許可外の content_type は invalid" do
+      memory.image.attach(
+        io: StringIO.new("malicious payload"),
+        filename: "evil.exe",
+        content_type: "application/octet-stream"
+      )
+      expect(memory).not_to be_valid
+      expect(memory.errors[:image]).to include("はJPEG、JPG、PNGのみアップロード可能です")
+    end
+  end
+
+  describe "image の size バリデーション" do
+    let(:memory) { build(:memory) }
+
+    it "10MB ちょうどは valid" do
+      allow(memory.image.blob).to receive(:byte_size).and_return(Memory::MAX_IMAGE_SIZE)
+      expect(memory).to be_valid
+    end
+
+    it "10MB を超える image は invalid" do
+      allow(memory.image.blob).to receive(:byte_size).and_return(Memory::MAX_IMAGE_SIZE + 1)
+      expect(memory).not_to be_valid
+      expect(memory.errors[:image]).to include("は10MB以下にしてください")
+    end
+  end
+
+  describe "children_must_belong_to_user_family_group バリデーション" do
+    let(:user) { create(:user) }
+    let(:family_group) { create(:family_group) }
+    before { create(:user_family_group, user: user, family_group: family_group) }
+
+    it "children が空なら valid" do
+      memory = build(:memory, user: user)
+      expect(memory).to be_valid
+    end
+
+    it "user の家族グループに属する children なら valid" do
+      child = create(:child, family_group: family_group)
+      memory = build(:memory, user: user)
+      memory.children = [ child ]
+      expect(memory).to be_valid
+    end
+
+    it "user の家族グループに属さない children を紐付けると invalid" do
+      other_group = create(:family_group)
+      other_child = create(:child, family_group: other_group)
+      memory = build(:memory, user: user)
+      memory.children = [ other_child ]
+      expect(memory).not_to be_valid
+      expect(memory.errors[:children]).to be_present
+    end
+  end
+
 end

--- a/spec/models/memory_spec.rb
+++ b/spec/models/memory_spec.rb
@@ -153,4 +153,62 @@ RSpec.describe Memory, type: :model do
     end
   end
 
+  describe "#sync_tags_from_input (after_save)" do
+    let(:user) { create(:user) }
+
+    it "tag_list_input が nil なら何もしない（early return）" do
+      memory = create(:memory, user: user, tag_list_input: nil)
+      expect(memory.tags).to be_empty
+    end
+
+    it "空文字または空白のみは 0 件" do
+      memory = create(:memory, user: user, tag_list_input: "")
+      expect(memory.tags).to be_empty
+    end
+
+    it "空白カンマのみの入力も 0 件（reject(&:blank?)）" do
+      memory = create(:memory, user: user, tag_list_input: "  ,  ,  ")
+      expect(memory.tags).to be_empty
+    end
+
+    it "カンマ区切り入力からタグを作成する" do
+      memory = create(:memory, user: user, tag_list_input: "どんぐり,葉っぱ,折り紙")
+      expect(memory.tags.map(&:name)).to contain_exactly("どんぐり", "葉っぱ", "折り紙")
+    end
+
+    it "各タグの前後の空白は strip される" do
+      memory = create(:memory, user: user, tag_list_input: " どんぐり , 葉っぱ ")
+      expect(memory.tags.map(&:name)).to contain_exactly("どんぐり", "葉っぱ")
+    end
+
+    it "重複したタグは除外される" do
+      memory = create(:memory, user: user, tag_list_input: "どんぐり,どんぐり,葉っぱ")
+      expect(memory.tags.map(&:name)).to contain_exactly("どんぐり", "葉っぱ")
+    end
+
+    it "TAG_LIMIT (10) を超える分は無視される" do
+      names = (1..15).map { |n| "tag#{n}" }
+      memory = create(:memory, user: user, tag_list_input: names.join(","))
+      expect(memory.tags.count).to eq(Memory::TAG_LIMIT)
+      expect(memory.tags.map(&:name)).to contain_exactly(*names.first(Memory::TAG_LIMIT))
+    end
+
+    it "TAG_MAX_LENGTH (30) を超えるタグは黙って無視される" do
+      long_name = "あ" * (Memory::TAG_MAX_LENGTH + 1)
+      memory = create(:memory, user: user, tag_list_input: "#{long_name},短いタグ")
+      expect(memory.tags.map(&:name)).to contain_exactly("短いタグ")
+    end
+
+    it "作成されたタグは投稿者の user に紐付く" do
+      memory = create(:memory, user: user, tag_list_input: "テスト")
+      expect(memory.tags.first.user).to eq(user)
+    end
+
+    it "既存タグがあれば再作成せず参照する（find_or_create_by!）" do
+      user.tags.create!(name: "既存")
+      expect {
+        create(:memory, user: user, tag_list_input: "既存,新規")
+      }.to change { user.tags.count }.by(1) # 新規 1 件のみ追加
+    end
+  end
 end


### PR DESCRIPTION
## 概要
  Memory モデルの未テストロジックのうち、影響範囲の大きい 2 領域に spec を追加:
  - **カスタムバリデーション** : image content_type / image size / children_must_belong_to_user_family_group
  - **タグ同期コールバック** : `sync_tags_from_input` の文字列パース・上限・重複除外 等の分岐網羅

  これに伴い `family_group` / `user_family_group` / `child` の最小 factory も整備。

## 変更ファイル一覧
  | ファイル | 種別 | 変更理由 |
  |---------|------|---------|
  | `spec/factories/family_groups.rb` | 新規 | 子テストで使う最小 factory |
  | `spec/factories/user_family_groups.rb` | 新規 | role: member デフォルト |
  | `spec/factories/children.rb` | 新規 | family_group 必須の最小 factory |
  | `spec/models/memory_spec.rb` | 修正 | カスタムバリデーション + タグ同期 spec を追加（+18 examples） |

  ## 実装のポイント

  ### カスタムバリデーション
  | 観点 | テスト技法 |
  |---|---|
  | image content_type | 同じ image に StringIO で不正 content_type を再 attach して invalid 確認 |
  | image size | `allow(memory.image.blob).to receive(:byte_size)` でスタブ。大容量ファイルをリポジトリに置かない |
  | children belongs to family group | `before { create(:user_family_group, ...) }` で前提構築後、別 family_group の Child を紐付けて invalid 確認 |

  ### タグ同期（after_save）
  `tag_list_input` は仮想属性（DB 保存されない）。`create(:memory, tag_list_input: "...")` で渡すと `after_save :sync_tags_from_input` が発火。以下の分岐を網羅:

  - `nil` → early return（既存タグ非干渉）
  - 空文字 / 空白カンマのみ → 0 件
  - 通常入力 → カンマ split + strip + reject(&:blank?) + uniq
  - `TAG_LIMIT` (10) 超過 → 先頭 10 件のみ
  - `TAG_MAX_LENGTH` (30) 超過タグ → 静かに無視（投稿失敗にしない）
  - タグは投稿者 user に紐付く
  - 既存タグは `find_or_create_by!` で再利用（user_id, name の unique 制約と整合）

