### PR TITLE
5 つの Policy（UserFamilyGroup / FamilyGroup / Invitation / Child / Reaction）の RSpec を追加

### DIFF
--- a/spec/factories/invitations.rb
+++ b/spec/factories/invitations.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :invitation do
+    family_group
+    # token / expires_at は Invitation#generate_token (before_create) で自動採番される
+  end
+end

--- a/spec/factories/reactions.rb
+++ b/spec/factories/reactions.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :reaction do
+    user
+    memory
+    reaction_type { :thumbs_up }
+  end
+end

--- a/spec/policies/child_policy_spec.rb
+++ b/spec/policies/child_policy_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+RSpec.describe ChildPolicy, type: :policy do
+  subject { described_class }
+
+  let(:group_a)  { create(:family_group) }
+  let(:group_b)  { create(:family_group) }
+  let(:a_owner)  { create(:user) }
+  let(:a_member) { create(:user) }
+  let(:b_owner)  { create(:user) }
+  let(:stranger) { create(:user) }
+
+  before do
+    create(:user_family_group, user: a_owner,  family_group: group_a, role: :owner)
+    create(:user_family_group, user: a_member, family_group: group_a, role: :member)
+    create(:user_family_group, user: b_owner,  family_group: group_b, role: :owner)
+  end
+
+  let(:child_a) { create(:child, family_group: group_a) }
+  let(:child_b) { create(:child, family_group: group_b) }
+
+  describe "permissions" do
+    # 親リソース(FamilyGroup) のメンバー検証は controller の before_action で行う設計のため、
+    # Policy 単体では index? / show? は常に true。
+    permissions :index?, :show? do
+      it "ログイン状態を問わず true（実際の閲覧制御は controller で行う設計）" do
+        expect(subject).to permit(stranger, child_a)
+        expect(subject).to permit(nil,      child_a)
+      end
+    end
+
+    # 書き込み系は owner のみ。member は閲覧できても child を編集・削除できない
+    permissions :create?, :new?, :update?, :edit?, :destroy? do
+      it "同じグループの owner なら true" do
+        expect(subject).to permit(a_owner, child_a)
+      end
+
+      it "同じグループの member は false（閲覧はできるが書き込み不可）" do
+        expect(subject).not_to permit(a_member, child_a)
+      end
+
+      it "別グループの owner は false" do
+        expect(subject).not_to permit(b_owner, child_a)
+      end
+
+      it "未所属の user は false" do
+        expect(subject).not_to permit(stranger, child_a)
+      end
+
+      it "未ログインは false" do
+        expect(subject).not_to permit(nil, child_a)
+      end
+    end
+  end
+
+  describe ChildPolicy::Scope do
+    let!(:child_a1) { create(:child, family_group: group_a) }
+    let!(:child_a2) { create(:child, family_group: group_a) }
+    let!(:child_b1) { create(:child, family_group: group_b) }
+
+    it "未ログインなら 0 件" do
+      expect(described_class.new(nil, Child).resolve).to be_empty
+    end
+
+    it "owner には自グループの子全てが返る" do
+      result = described_class.new(a_owner, Child).resolve
+      expect(result).to contain_exactly(child_a1, child_a2)
+    end
+
+    it "member にも自グループの子全てが返る（閲覧は member も可）" do
+      result = described_class.new(a_member, Child).resolve
+      expect(result).to contain_exactly(child_a1, child_a2)
+    end
+
+    it "別グループの子は含まれない" do
+      result = described_class.new(a_owner, Child).resolve
+      expect(result).not_to include(child_b1)
+    end
+
+    # 早期 return の動作確認
+    it "family_group 未所属の user は 0 件（pluck が空配列 → 早期 return）" do
+      expect(described_class.new(stranger, Child).resolve).to be_empty
+    end
+  end
+end

--- a/spec/policies/family_group_policy_spec.rb
+++ b/spec/policies/family_group_policy_spec.rb
@@ -1,0 +1,128 @@
+require "rails_helper"
+
+RSpec.describe FamilyGroupPolicy, type: :policy do
+  subject { described_class }
+
+  let(:group_a)  { create(:family_group) }
+  let(:group_b)  { create(:family_group) }
+  let(:a_owner)  { create(:user) }
+  let(:a_member) { create(:user) }
+  let(:b_owner)  { create(:user) }
+  let(:stranger) { create(:user) } # どのグループにも属さない
+
+  before do
+    create(:user_family_group, user: a_owner,  family_group: group_a, role: :owner)
+    create(:user_family_group, user: a_member, family_group: group_a, role: :member)
+    create(:user_family_group, user: b_owner,  family_group: group_b, role: :owner)
+  end
+
+  describe "permissions" do
+    permissions :index? do
+      it "ログイン済みなら true（所属有無は問わない）" do
+        expect(subject).to permit(stranger, FamilyGroup.new)
+      end
+
+      it "未ログインは false" do
+        expect(subject).not_to permit(nil, FamilyGroup.new)
+      end
+    end
+
+    permissions :show? do
+      it "所属メンバー（owner）なら true" do
+        expect(subject).to permit(a_owner, group_a)
+      end
+
+      it "所属メンバー（member）なら true" do
+        expect(subject).to permit(a_member, group_a)
+      end
+
+      it "別グループの owner は false" do
+        expect(subject).not_to permit(b_owner, group_a)
+      end
+
+      it "未所属の user は false" do
+        expect(subject).not_to permit(stranger, group_a)
+      end
+
+      it "未ログインは false" do
+        expect(subject).not_to permit(nil, group_a)
+      end
+    end
+
+    permissions :create?, :new? do
+      # 1 ユーザー 1 グループ制約: 未所属の user のみ作成可能
+      it "未所属の user なら true" do
+        expect(subject).to permit(stranger, FamilyGroup.new)
+      end
+
+      it "既に owner として所属している user は false" do
+        expect(subject).not_to permit(a_owner, FamilyGroup.new)
+      end
+
+      it "既に member として所属している user は false" do
+        expect(subject).not_to permit(a_member, FamilyGroup.new)
+      end
+
+      it "未ログインは false" do
+        expect(subject).not_to permit(nil, FamilyGroup.new)
+      end
+    end
+
+    permissions :update?, :edit? do
+      it "owner なら true" do
+        expect(subject).to permit(a_owner, group_a)
+      end
+
+      it "member は false（ロール権限が必要）" do
+        expect(subject).not_to permit(a_member, group_a)
+      end
+
+      it "別グループの owner は false" do
+        expect(subject).not_to permit(b_owner, group_a)
+      end
+
+      it "未ログインは false" do
+        expect(subject).not_to permit(nil, group_a)
+      end
+    end
+
+    permissions :destroy? do
+      it "owner なら true" do
+        expect(subject).to permit(a_owner, group_a)
+      end
+
+      it "member は false（グループ削除はできない）" do
+        expect(subject).not_to permit(a_member, group_a)
+      end
+
+      it "未ログインは false" do
+        expect(subject).not_to permit(nil, group_a)
+      end
+    end
+  end
+
+  describe FamilyGroupPolicy::Scope do
+    it "未ログインなら 0 件" do
+      expect(described_class.new(nil, FamilyGroup).resolve).to be_empty
+    end
+
+    it "owner には自分の所属グループが返る" do
+      result = described_class.new(a_owner, FamilyGroup).resolve
+      expect(result).to contain_exactly(group_a)
+    end
+
+    it "member にも自分の所属グループが返る（owner/member で差はない）" do
+      result = described_class.new(a_member, FamilyGroup).resolve
+      expect(result).to contain_exactly(group_a)
+    end
+
+    it "別グループの owner からは自グループのみ見える" do
+      result = described_class.new(b_owner, FamilyGroup).resolve
+      expect(result).to contain_exactly(group_b)
+    end
+
+    it "未所属の user は 0 件" do
+      expect(described_class.new(stranger, FamilyGroup).resolve).to be_empty
+    end
+  end
+end

--- a/spec/policies/invitation_policy_spec.rb
+++ b/spec/policies/invitation_policy_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe InvitationPolicy, type: :policy do
+  subject { described_class }
+
+  let(:group_a)  { create(:family_group) }
+  let(:group_b)  { create(:family_group) }
+  let(:a_owner)  { create(:user) }
+  let(:a_member) { create(:user) }
+  let(:b_owner)  { create(:user) }
+  let(:stranger) { create(:user) }
+
+  before do
+    create(:user_family_group, user: a_owner,  family_group: group_a, role: :owner)
+    create(:user_family_group, user: a_member, family_group: group_a, role: :member)
+    create(:user_family_group, user: b_owner,  family_group: group_b, role: :owner)
+  end
+
+  let(:invitation_a) { create(:invitation, family_group: group_a) }
+  let(:invitation_b) { create(:invitation, family_group: group_b) }
+
+  # 招待リンクの発行・閲覧・削除は全て group_owner? を要求するため、
+  # 4 つの permission をひとまとめに同じ user 種別で検証する
+  describe "permissions (index? / show? / create? / destroy?)" do
+    permissions :index?, :show?, :create?, :destroy? do
+      it "同じグループの owner なら true" do
+        expect(subject).to permit(a_owner, invitation_a)
+      end
+
+      it "同じグループの member は false（owner だけが招待を扱える）" do
+        expect(subject).not_to permit(a_member, invitation_a)
+      end
+
+      it "別グループの owner は false" do
+        expect(subject).not_to permit(b_owner, invitation_a)
+      end
+
+      it "未所属の user は false" do
+        expect(subject).not_to permit(stranger, invitation_a)
+      end
+
+      it "未ログインは false" do
+        expect(subject).not_to permit(nil, invitation_a)
+      end
+    end
+  end
+
+  describe InvitationPolicy::Scope do
+    let!(:inv_a) { create(:invitation, family_group: group_a) }
+    let!(:inv_b) { create(:invitation, family_group: group_b) }
+
+    it "未ログインなら 0 件" do
+      expect(described_class.new(nil, Invitation).resolve).to be_empty
+    end
+
+    it "owner には自分が owner であるグループの招待が返る" do
+      result = described_class.new(a_owner, Invitation).resolve
+      expect(result).to contain_exactly(inv_a)
+    end
+
+    it "別グループの owner からは自グループの招待のみ見える" do
+      result = described_class.new(b_owner, Invitation).resolve
+      expect(result).to contain_exactly(inv_b)
+    end
+
+    # owner と member を区別するスコープであることの保証
+    it "member は 0 件（同じグループでも owner ロールがなければ招待は見えない）" do
+      expect(described_class.new(a_member, Invitation).resolve).to be_empty
+    end
+
+    it "未所属の user は 0 件" do
+      expect(described_class.new(stranger, Invitation).resolve).to be_empty
+    end
+  end
+end

--- a/spec/policies/reaction_policy_spec.rb
+++ b/spec/policies/reaction_policy_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe ReactionPolicy, type: :policy do
+  subject { described_class }
+
+  let(:memory_author) { create(:user) }
+  let(:reactor)       { create(:user) }
+  let(:other_user)    { create(:user) }
+  let(:memory)        { create(:memory, user: memory_author, visibility: :published) }
+  let(:reaction)      { create(:reaction, user: reactor, memory: memory) }
+
+  describe "permissions" do
+    permissions :destroy? do
+      it "自分のリアクションなら true" do
+        expect(subject).to permit(reactor, reaction)
+      end
+
+      it "他人のリアクションは削除できない（false）" do
+        expect(subject).not_to permit(other_user, reaction)
+      end
+
+      # 「リアクションを受けた投稿の作者」であっても削除権限はない
+      it "memory の投稿者であっても他人のリアクションは削除できない（false）" do
+        expect(subject).not_to permit(memory_author, reaction)
+      end
+
+      it "未ログインは false" do
+        expect(subject).not_to permit(nil, reaction)
+      end
+    end
+  end
+end

--- a/spec/policies/user_family_group_policy_spec.rb
+++ b/spec/policies/user_family_group_policy_spec.rb
@@ -1,0 +1,164 @@
+require "rails_helper"
+
+RSpec.describe UserFamilyGroupPolicy, type: :policy do
+  subject { described_class }
+
+  # 登場人物
+  # - group_a / group_b の 2 つの家族グループ
+  # - group_a に owner (a_owner) と member (a_member) を所属させる
+  # - group_b に owner (b_owner) を所属させる（別グループの owner）
+  # - stranger はどこにも所属しない
+  let(:group_a)  { create(:family_group) }
+  let(:group_b)  { create(:family_group) }
+  let(:a_owner)  { create(:user) }
+  let(:a_member) { create(:user) }
+  let(:b_owner)  { create(:user) }
+  let(:stranger) { create(:user) }
+
+  let!(:a_owner_membership)  { create(:user_family_group, user: a_owner,  family_group: group_a, role: :owner) }
+  let!(:a_member_membership) { create(:user_family_group, user: a_member, family_group: group_a, role: :member) }
+  let!(:b_owner_membership)  { create(:user_family_group, user: b_owner,  family_group: group_b, role: :owner) }
+
+  describe "permissions" do
+    permissions :show? do
+      it "同じグループの owner なら true" do
+        expect(subject).to permit(a_owner, a_member_membership)
+      end
+
+      it "同じグループの member 同士でも true（same_group_member）" do
+        expect(subject).to permit(a_member, a_owner_membership)
+      end
+
+      it "別グループのメンバーシップは false" do
+        expect(subject).not_to permit(a_owner, b_owner_membership)
+      end
+
+      it "未所属の user は false" do
+        expect(subject).not_to permit(stranger, a_owner_membership)
+      end
+
+      it "未ログインは false" do
+        expect(subject).not_to permit(nil, a_owner_membership)
+      end
+    end
+
+    permissions :create? do
+      # 招待経由の自己参加を許可するため、record.user_id == 自分自身のみ true
+      it "自分自身のメンバーシップを作るなら true" do
+        new_membership = build(:user_family_group, user: stranger, family_group: group_a)
+        expect(subject).to permit(stranger, new_membership)
+      end
+
+      it "他人のメンバーシップを作ろうとすると false（なりすまし禁止）" do
+        new_membership = build(:user_family_group, user: a_member, family_group: group_a)
+        expect(subject).not_to permit(stranger, new_membership)
+      end
+
+      it "未ログインは false" do
+        new_membership = build(:user_family_group, user: stranger, family_group: group_a)
+        expect(subject).not_to permit(nil, new_membership)
+      end
+    end
+
+    permissions :update? do
+      # group_owner? のみ許可。member が自分のロールを書き換えて owner 昇格できない保証も兼ねる
+      it "同じグループの owner なら true" do
+        expect(subject).to permit(a_owner, a_member_membership)
+      end
+
+      it "同じグループの member は false（ロール昇格できない）" do
+        expect(subject).not_to permit(a_member, a_member_membership)
+      end
+
+      it "別グループの owner は false" do
+        expect(subject).not_to permit(b_owner, a_member_membership)
+      end
+
+      it "未ログインは false" do
+        expect(subject).not_to permit(nil, a_member_membership)
+      end
+    end
+
+    permissions :destroy? do
+      # self_membership? || group_owner? — 自己脱退と owner による kick の両方を許可
+      it "自分自身のメンバーシップ（自己脱退）なら true" do
+        expect(subject).to permit(a_member, a_member_membership)
+      end
+
+      it "同じグループの owner が member を削除（kick）なら true" do
+        expect(subject).to permit(a_owner, a_member_membership)
+      end
+
+      it "同じグループの member が他人を削除しようとしたら false" do
+        expect(subject).not_to permit(a_member, a_owner_membership)
+      end
+
+      it "別グループの owner は false" do
+        expect(subject).not_to permit(b_owner, a_member_membership)
+      end
+
+      it "未ログインは false" do
+        expect(subject).not_to permit(nil, a_member_membership)
+      end
+    end
+
+    permissions :leave? do
+      # 自分自身のメンバーシップに対する操作のみ true（view の脱退ボタン表示判定）
+      it "自分自身のメンバーシップなら true" do
+        expect(subject).to permit(a_member, a_member_membership)
+      end
+
+      it "他人のメンバーシップは false（owner であっても他人の leave ボタンは出さない）" do
+        expect(subject).not_to permit(a_owner, a_member_membership)
+      end
+
+      it "未ログインは false" do
+        expect(subject).not_to permit(nil, a_member_membership)
+      end
+    end
+
+    permissions :kick? do
+      # group_owner? && !self_membership? — 自分自身を kick できないように除外
+      it "同じグループの owner が他のメンバーを kick なら true" do
+        expect(subject).to permit(a_owner, a_member_membership)
+      end
+
+      it "owner が自分自身を kick しようとしても false（kick ボタンを自行に出さない）" do
+        expect(subject).not_to permit(a_owner, a_owner_membership)
+      end
+
+      it "member は kick できない（false）" do
+        expect(subject).not_to permit(a_member, a_owner_membership)
+      end
+
+      it "未ログインは false" do
+        expect(subject).not_to permit(nil, a_member_membership)
+      end
+    end
+  end
+
+  describe UserFamilyGroupPolicy::Scope do
+    it "未ログインなら 0 件" do
+      expect(described_class.new(nil, UserFamilyGroup).resolve).to be_empty
+    end
+
+    it "owner には同じグループの全メンバーシップが返る" do
+      result = described_class.new(a_owner, UserFamilyGroup).resolve
+      expect(result).to contain_exactly(a_owner_membership, a_member_membership)
+    end
+
+    it "member にも同じグループの全メンバーシップが返る（owner/member で見え方は同じ）" do
+      result = described_class.new(a_member, UserFamilyGroup).resolve
+      expect(result).to contain_exactly(a_owner_membership, a_member_membership)
+    end
+
+    it "別グループのメンバーシップは含まれない" do
+      result = described_class.new(a_owner, UserFamilyGroup).resolve
+      expect(result).not_to include(b_owner_membership)
+    end
+
+    it "未所属の user は 0 件" do
+      expect(described_class.new(stranger, UserFamilyGroup).resolve).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
 ## 概要
  - 残り 5 つの Policy（UserFamilyGroup / FamilyGroup / Invitation / Child / Reaction）の RSpec を追加
  - 既存の Pundit Policy 認可ロジックを全カバー
  - 合計 77 examples（全体 185 examples, 0 failures）

  ## 変更ファイル一覧
  | ファイル | 種別 | 変更理由 |
  |---------|------|---------|
  | spec/factories/invitations.rb | 新規 | InvitationPolicy spec 用 factory |
  | spec/factories/reactions.rb | 新規 | ReactionPolicy spec 用 factory |
  | spec/policies/user_family_group_policy_spec.rb | 新規 | 認可漏れ防止（ロール昇格・なりすまし参加・kick/leave 分離） |
  | spec/policies/family_group_policy_spec.rb | 新規 | 1ユーザー1グループ制約検証 |
  | spec/policies/invitation_policy_spec.rb | 新規 | owner 限定の招待管理保証 |
  | spec/policies/child_policy_spec.rb | 新規 | 書き込み系の owner 限定 |
  | spec/policies/reaction_policy_spec.rb | 新規 | 自リアクション限定の削除権限 |

  ## 実装のポイント
  - セキュリティ重要度の高い分岐（ロール昇格防止 / なりすまし参加 / 自己 kick 防止）を明示テスト化
  - 5 つの spec をコミット単位で分割（レビュー時にコミット単位で確認可

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 招待機能、リアクション機能、権限管理システムの包括的なテストを追加。グループオーナー、メンバー、未ログインユーザーなど様々なシナリオでの動作を検証し、システムの安定性と信頼性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->