### PR TITLE
chore: shoulda-matchers を 6.x → 8.0.1 にメジャーアップデート

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -141,7 +141,7 @@ group :test do
   gem "minitest", "~> 5.25"
 
   # shoulda-matchers - Rails 慣用テストの一行記法
-  gem "shoulda-matchers", "~> 6.0"
+  gem "shoulda-matchers", "~> 8.0"
 
   # SimpleCov - テストカバレッジ計測
   # spec_helper.rb の冒頭で require して start させる必要があるため require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,7 +188,7 @@ GEM
       rake (~> 13.3)
     hashie (5.1.0)
       logger
-    i18n (1.15.1)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     image_processing (2.0.2)
     io-console (0.8.2)
@@ -466,8 +466,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
-    shoulda-matchers (6.5.0)
-      activesupport (>= 5.2.0)
+    shoulda-matchers (8.0.1)
+      activesupport (>= 7.2)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -571,7 +571,7 @@ DEPENDENCIES
   rubocop-rails-omakase
   ruby-vips (~> 2.0)
   selenium-webdriver
-  shoulda-matchers (~> 6.0)
+  shoulda-matchers (~> 8.0)
   simplecov
   sprockets-rails
   stimulus-rails


### PR DESCRIPTION
 ## 概要
  - Dependabot 提案の依存更新
  - Gemfile 制約: `~> 6.0` → `~> 8.0` (メジャー 2 上げ、8.0.1 解決)
  - 既存の Model spec / Policy spec で使用している matcher は互換維持されており、全 217 examples green

  ## 変更ファイル一覧
  | ファイル | 種別 | 変更理由 |
  |---------|------|---------|
  | Gemfile      | 修正 | バージョン制約を `~> 8.0` に更新 |
  | Gemfile.lock | 修正 | shoulda-matchers 6.x → 8.0.1 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * テスト関連の依存ライブラリをアップグレードしました。内部テストツールの動作改善により、開発効率が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->