### PR TITLE
細かいUIを調整、マイページの更新不具合を修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -33,3 +33,16 @@
     margin-bottom: 16px;
   }
 }
+
+/* MemoryGame クリアモーダルのポップイン */
+@layer utilities {
+  @keyframes pop-in {
+    0%   { opacity: 0; transform: scale(0.6); }
+    70%  { opacity: 1; transform: scale(1.08); }
+    100% { opacity: 1; transform: scale(1); }
+  }
+
+  .animate-pop-in {
+    animation: pop-in 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+}

--- a/app/javascript/react/MemoryGame.jsx
+++ b/app/javascript/react/MemoryGame.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useCallback, useMemo, useRef } from "react"
+import confetti from "canvas-confetti"
 
 // ── ユーティリティ ──────────────────────────────
 const shuffle = (arr) => [...arr].sort(() => Math.random() - 0.5)
@@ -137,30 +138,56 @@ const ScoreBoard = ({ moves, pairs, total, onReset }) => (
 )
 
 // ── クリアモーダル ──────────────────────────────
-const ClearModal = ({ moves, total, onReset }) => (
-  <div className="modal modal-open">
-    <div className="modal-box text-center">
-      <div className="text-6xl mb-4">🎉</div>
-      <h3 className="font-bold text-2xl mb-1">クリア！</h3>
-      <p className="text-base-content/70 mb-4">
-        <span className="text-primary font-bold text-xl">{moves}</span>
-        {" "}手でクリアしました！
-      </p>
-      <div className="divider" />
-      <p className="text-sm text-base-content/50 mb-4">
-        使用した思い出: {total}件
-      </p>
-      <div className="modal-action justify-center gap-3">
-        <button className="btn btn-primary" onClick={onReset}>
-          もう一度
-        </button>
-        <a href="/memories" className="btn btn-ghost">
-          投稿一覧へ
-        </a>
+const ClearModal = ({ moves, total, onReset }) => {
+  // クリア時に画面両端から紙吹雪を約 1.5 秒間連続発射する。
+  // requestAnimationFrame ループはモーダル unmount 時に active フラグで停止させる。
+  useEffect(() => {
+    let active = true
+    const end = Date.now() + 1500
+    const colors = ["#ff6b6b", "#feca57", "#48dbfb", "#1dd1a1", "#ee5a6f", "#a55eea"]
+    const tick = () => {
+      if (!active) return
+      confetti({ particleCount: 5, angle: 60,  spread: 55, origin: { x: 0 }, colors })
+      confetti({ particleCount: 5, angle: 120, spread: 55, origin: { x: 1 }, colors })
+      if (Date.now() < end) requestAnimationFrame(tick)
+    }
+    tick()
+    return () => { active = false }
+  }, [])
+
+  return (
+    <div className="modal modal-open">
+      <div className="modal-box text-center animate-pop-in">
+        <div className="text-7xl mb-3 inline-block animate-bounce">🎉</div>
+        <h3 className="font-bold text-3xl mb-2 text-primary">やったね！</h3>
+        <p className="text-base-content/80 text-lg mb-4">
+          ぜんぶ あわせられたね！
+        </p>
+
+        <div className="bg-base-200 rounded-2xl px-6 py-4 mb-4 inline-block">
+          <p className="text-xs text-base-content/60 mb-1">てすう</p>
+          <p className="text-4xl font-bold text-primary leading-none">
+            {moves}
+            <span className="text-base font-normal text-base-content/70"> てで クリア</span>
+          </p>
+        </div>
+
+        <p className="text-sm text-base-content/50 mb-5">
+          おもいでをつかったよ: {total}まい
+        </p>
+
+        <div className="modal-action justify-center gap-3">
+          <button className="btn btn-primary" onClick={onReset}>
+            もういちど あそぶ
+          </button>
+          <a href="/memories" className="btn btn-ghost">
+            おもいでをみる
+          </a>
+        </div>
       </div>
     </div>
-  </div>
-)
+  )
+}
 
 // ── 投稿不足 ────────────────────────────────────
 const InsufficientAlert = ({ needed }) => (
@@ -334,8 +361,8 @@ export default function MemoryGame() {
 
   return (
     <div className="min-h-screen bg-base-200 flex flex-col items-center py-10 px-4">
-      <h1 className="text-3xl font-bold mb-2">ミニメモリー神経衰弱🃏</h1>
-      <p className="text-base-content/60 mb-8">あなたのミニメモリーをカードゲームで振り返ろう</p>
+      <h1 className="text-3xl font-bold mb-2">おもいでカードあわせ✨</h1>
+      <p className="text-base-content/60 mb-8">おなじカードを みつけてみよう！</p>
 
       {status === "loading" && (
         <span className="loading loading-spinner loading-lg text-primary" />

--- a/app/javascript/react/MemoryGame.jsx
+++ b/app/javascript/react/MemoryGame.jsx
@@ -141,7 +141,9 @@ const ScoreBoard = ({ moves, pairs, total, onReset }) => (
 const ClearModal = ({ moves, total, onReset }) => {
   // クリア時に画面両端から紙吹雪を約 1.5 秒間連続発射する。
   // requestAnimationFrame ループはモーダル unmount 時に active フラグで停止させる。
+  // prefers-reduced-motion 設定のユーザーには紙吹雪を発射しない。
   useEffect(() => {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return
     let active = true
     const end = Date.now() + 1500
     const colors = ["#ff6b6b", "#feca57", "#48dbfb", "#1dd1a1", "#ee5a6f", "#a55eea"]
@@ -157,8 +159,8 @@ const ClearModal = ({ moves, total, onReset }) => {
 
   return (
     <div className="modal modal-open">
-      <div className="modal-box text-center animate-pop-in">
-        <div className="text-7xl mb-3 inline-block animate-bounce">🎉</div>
+      <div className="modal-box text-center motion-safe:animate-pop-in">
+        <div className="text-7xl mb-3 inline-block motion-safe:animate-bounce">🎉</div>
         <h3 className="font-bold text-3xl mb-2 text-primary">やったね！</h3>
         <p className="text-base-content/80 text-lg mb-4">
           ぜんぶ あわせられたね！

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -23,7 +23,7 @@
           <%= render "shared/error_messages", object: resource %>
 
           <div id="avatar-preview" class="flex flex-col items-center gap-2">
-            <% if resource.avatar.attached? %>
+            <% if resource.avatar.attached? && resource.avatar.blob&.persisted? %>
               <div class="avatar">
                 <div class="w-20 h-20 rounded-full overflow-hidden">
                   <%= image_tag resource.avatar, class: "w-full h-full object-cover", alt: resource.name %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="navbar bg-base-100 shadow-sm">
+<header class="navbar bg-base-100 shadow-sm sticky top-0 z-50">
   <div class="navbar-start">
     <!-- drawer トリガー -->
     <label for="drawer-menu" class="btn btn-ghost btn-circle">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,7 +10,10 @@
 
   <!-- 中央タイトル -->
   <div class="navbar-center">
-    <%= link_to "minimemory", root_path, class: "btn btn-ghost text-xl" %>
+    <%= link_to root_path, class: "btn btn-ghost gap-2" do %>
+      <%= image_tag "/minimemory_icon.svg", alt: "", aria: { hidden: true }, class: "h-8 w-auto" %>
+      <span class="text-xl">minimemory</span>
+    <% end %>
   </div>
 
   <!-- ユーザーアイコン -->

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.20",
     "@tailwindcss/cli": "^4.1.18",
+    "canvas-confetti": "^1.9.4",
     "daisyui": "^5.5.14",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -434,6 +434,11 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
+canvas-confetti@^1.9.4:
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/canvas-confetti/-/canvas-confetti-1.9.4.tgz#4412a5daa96afd0b4d70ecd66b65ce8db3022b2b"
+  integrity sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==
+
 daisyui@^5.5.14:
   version "5.5.14"
   resolved "https://registry.yarnpkg.com/daisyui/-/daisyui-5.5.14.tgz#818487da886730f6338f51d0414c32159c297cad"


### PR DESCRIPTION
## 概要
  細かい UI 改修と挙動の不具合修正。

  ## 含まれる変更

  ### ヘッダー UI
  - ヘッダーをスクロールしても上端に追従する sticky 表示に変更
  - 中央のサイトタイトルを SVG ロゴアイコン + テキストの組み合わせに変更
    - スクリーンリーダーで二重に読まれないよう alt="" / aria-hidden を適切に設定

  ### 神経衰弱ゲームの子供向けリニューアル
  - タイトル「ミニメモリー神経衰弱🃏」→ 「おもいでカードあわせ✨」
  - サブタイトル「あなたのミニメモリーをカードゲームで振り返ろう」
    → 「おなじカードを みつけてみよう！」
  - クリアモーダルの文言をひらがな主体に統一（「やったね！」「もういちど あそぶ」など）
  - クリアモーダルを `animate-pop-in`（カスタム keyframes）で弾けるように登場
  - 絵文字を `animate-bounce` で跳ねさせる
  - `canvas-confetti` を導入し、クリア時に画面両端から 1.5 秒の紙吹雪を発射

  ### バグ修正
  - アカウント編集画面でアバター画像と名前を更新したとき、バリデーション失敗時に
    `ArgumentError: Cannot get a signed_id for a new record` で 500 になる問題を修正
  - `avatar.attached?` に加えて `blob.persisted?` を確認

  ## 変更ファイル一覧
  | ファイル | 種別 | 変更理由 |
  |---------|------|---------|
  | app/views/shared/_header.html.erb | 修正 | 上部に貼り付け + ロゴ + テキスト表示 |
  | app/javascript/react/MemoryGame.jsx | 修正 | タイトル / クリア演出リニューアル + 紙吹雪 |
  | app/assets/stylesheets/application.tailwind.css | 修正 | pop-in keyframe 追加 |
  | package.json / yarn.lock | 修正 | canvas-confetti 追加 |
  | app/views/devise/registrations/edit.html.erb | 修正 | 未永続化 blob による 500 修正 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ゲームクリア時に紙吹雪エフェクトを表示します（動きが苦手な場合は無効化します）
  * クリアモーダルのポップイン演出を追加しました
* **改善**
  * ヘッダーを常時固定し、ブランドをアイコン付きに更新しました
  * ゲーム画面の見出し・説明文言を更新しました
  * アバター画像の表示条件を改善しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->