### PR TITLE
dependabot 2 件をまとめて更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       # 代替で application.tailwind.css (SCSS) を読み込み、
       # dartsass-sprockets が Tailwind 出力を SCSS として parse して失敗する。
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: npm

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,7 +201,7 @@ GEM
       activesupport (>= 7.0.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.18.0)
+    json (2.20.0)
     jwt (3.1.2)
       base64
     kaminari (1.2.2)
@@ -307,7 +307,7 @@ GEM
     pg (1.6.3-x86_64-darwin)
     pg (1.6.3-x86_64-linux)
     pg (1.6.3-x86_64-linux-musl)
-    pp (0.6.3)
+    pp (0.6.4)
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
@@ -513,11 +513,10 @@ GEM
     version_gem (1.1.9)
     warden (1.2.9)
       rack (>= 2.0.9)
-    web-console (4.2.1)
-      actionview (>= 6.0.0)
-      activemodel (>= 6.0.0)
+    web-console (4.3.0)
+      actionview (>= 8.0.0)
       bindex (>= 0.4.0)
-      railties (>= 6.0.0)
+      railties (>= 8.0.0)
     websocket (1.2.11)
     websocket-driver (0.8.1)
       base64


### PR DESCRIPTION
## 概要
  - Dependabot 提案の 2 件の依存更新をまとめて取り込み
    - web-console 4.2.1 → 4.3.0
    - actions/setup-node v4 → v6

  ## 本番影響
  - web-console は `group :development` 配下 → 本番影響なし
  - actions/setup-node は CI のみ → 本番影響なし

  ## 変更ファイル一覧
  | ファイル | 種別 | 変更理由 |
  |---------|------|---------|
  | Gemfile.lock | 修正 | web-console を 4.3.0 に bump |
  | .github/workflows/ci.yml | 修正 | actions/setup-node v4 → v6 |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI の Node.js セットアップを更新し、テスト実行環境を最新にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->