### PR TITLE
画像処理中にスピナーモーダルを表示する

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -18,3 +18,6 @@ application.register("memory-image-preview", MemoryImagePreviewController)
 
 import AvatarPreviewController from "./avatar_preview_controller"
 application.register("avatar-preview", AvatarPreviewController)
+
+import ProcessingModalController from "./processing_modal_controller"
+application.register("processing-modal", ProcessingModalController)

--- a/app/javascript/controllers/processing_modal_controller.js
+++ b/app/javascript/controllers/processing_modal_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+// フォーム送信中(同期の画像処理の数秒間)だけモーダルのスピナーを表示する。
+// turbo:submit-start で開き、turbo:submit-end(レスポンス受信)で閉じる。
+export default class extends Controller {
+  static targets = ["modal"]
+
+  show() {
+    // 新しい画像が選択されている時だけ表示（編集で画像未変更ならリクエストは速いので出さない）
+    const fileInput = this.element.querySelector('input[type="file"]')
+    if (fileInput && fileInput.files.length === 0) return
+
+    this.modalTarget.classList.remove("hidden")
+  }
+
+  hide() {
+    this.modalTarget.classList.add("hidden")
+  }
+}

--- a/app/views/memories/_processing_modal.html.erb
+++ b/app/views/memories/_processing_modal.html.erb
@@ -1,0 +1,9 @@
+<%# フォーム送信中(同期の画像処理の数秒間)だけ表示するスピナー付きモーダル。
+    processing-modal controller が turbo:submit-start / submit-end で開閉する。 %>
+<div data-processing-modal-target="modal"
+     class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+  <div class="bg-base-100 rounded-2xl px-8 py-6 flex flex-col items-center gap-3 shadow-xl">
+    <span class="loading loading-spinner loading-lg text-primary"></span>
+    <span class="text-sm text-base-content/70"><%= t("memories.processing_modal.message") %></span>
+  </div>
+</div>

--- a/app/views/memories/edit.html.erb
+++ b/app/views/memories/edit.html.erb
@@ -24,7 +24,9 @@
     <!-- メインカード -->
     <div class="card bg-base-100 shadow-2xl border border-base-200">
       <div class="card-body p-6 gap-4">
-        <%= form_with model: @memory do |f| %>
+        <%= form_with model: @memory,
+              data: { controller: "processing-modal",
+                      action: "turbo:submit-start->processing-modal#show turbo:submit-end->processing-modal#hide" } do |f| %>
           <%# バリデーション失敗時に turbo_stream で中身だけ差し替えるため id 付きコンテナで囲む %>
           <div id="error_explanation_container">
             <%= render 'shared/error_messages', object: f.object %>
@@ -145,6 +147,7 @@
             <%= f.submit nil, class: "btn btn-primary btn-sm px-6" %>
           </div>
 
+          <%= render "memories/processing_modal" %>
         <% end %>
       </div>
     </div>

--- a/app/views/memories/new.html.erb
+++ b/app/views/memories/new.html.erb
@@ -24,7 +24,9 @@
     <!-- メインカード -->
     <div class="card bg-base-100 shadow-2xl border border-base-200">
       <div class="card-body p-6 gap-4">
-        <%= form_with model: @memory do |f| %>
+        <%= form_with model: @memory,
+              data: { controller: "processing-modal",
+                      action: "turbo:submit-start->processing-modal#show turbo:submit-end->processing-modal#hide" } do |f| %>
           <%# バリデーション失敗時に turbo_stream で中身だけ差し替えるため id 付きコンテナで囲む %>
           <div id="error_explanation_container">
             <%= render 'shared/error_messages', object: f.object %>
@@ -138,6 +140,7 @@
             <%= f.submit nil, class: "btn btn-primary btn-sm px-6" %>
           </div>
 
+          <%= render "memories/processing_modal" %>
         <% end %>
       </div>
     </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -87,6 +87,8 @@ ja:
       placeholder: タイトル・本文・タグで検索
       submit: 検索
       filter_label: 絞り込み検索
+    processing_modal:
+      message: 画像を処理しています…
   public_memories:
     index:
       title: 掲示板


### PR DESCRIPTION
## 概要
投稿/編集フォームの送信中、サーバー側の同期的な画像処理（Vips による webp 変換）に
数秒かかる間、ユーザーに進行状況が分かるよう「画像を処理しています…」のスピナー付き
モーダルを表示する UX 改善。

## 含まれる変更

### 送信中スピナーモーダル
- フォーム送信中だけ、画面全面のモーダル（暗幕 + ぐるぐるスピナー + 文言）を表示
- Turbo のフォーム送信イベントに反応させて開閉
  - `turbo:submit-start` → 表示 / `turbo:submit-end`（レスポンス受信）→ 非表示
  - 成功時は一覧へ遷移、バリデーションエラー時はフォーム再描画 + モーダルを閉じる
- 新しい画像が選択されている時だけ表示（編集で画像未変更＝高速リクエストでは出さない）
- 表示は daisyUI の `loading loading-spinner`、暗幕は `bg-black/50`
- 表示文言は i18n（`memories.processing_modal.message`）で外出し

### 実装方式
- `processing-modal` という Stimulus コントローラを追加し、`show` / `hide` で
  モーダルの `hidden` クラスを付け外しするだけのシンプルな構成
- ActionCable / ポーリングは不要（同期処理のままなので Turbo のイベントで完結）

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| app/javascript/controllers/processing_modal_controller.js | 新規 | 送信中にモーダルを開閉する Stimulus コントローラ |
| app/javascript/controllers/index.js | 修正 | `processing-modal` コントローラを登録 |
| app/views/memories/_processing_modal.html.erb | 新規 | スピナー付きモーダル本体（暗幕 + spinner + 文言） |
| app/views/memories/new.html.erb | 修正 | form_with に controller/action を付与、モーダルを描画 |
| app/views/memories/edit.html.erb | 修正 | 同上（編集フォームにも適用） |
| config/locales/views/ja.yml | 修正 | モーダル文言の翻訳を追加 |

## 実装のポイント
- 「重い同期処理の待ち時間を隠さず、状態を可視化する」だけのフロント施策
- モーダルはフォーム内に配置し、コントローラのスコープ内に置くことで `modalTarget` を解決
- `turbo:submit-end` は成功・失敗どちらでも発火するため、確実にモーダルが閉じる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 画像の送信・更新中に、処理中であることを示すモーダルとスピナーを表示するようになりました。
  * 画像が未選択の場合は、モーダルを表示しないようになりました。
* **改善**
  * 画像処理中の案内文言を追加し、より分かりやすい表示になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->