### PR TITLE
リクエストスペック追加でカバレッジ向上（reactions / children / family_groups）

### DIFF
--- a/spec/requests/children_spec.rb
+++ b/spec/requests/children_spec.rb
@@ -1,0 +1,153 @@
+require "rails_helper"
+
+RSpec.describe "Children", type: :request do
+  # owner    … グループのオーナー（こどもの作成/更新/削除が可能）
+  # member   … グループのメンバー（閲覧のみ）
+  # outsider … 非メンバー（存在を隠すため 404）
+  let(:group)    { create(:family_group) }
+  let(:owner)    { create(:user) }
+  let(:member)   { create(:user) }
+  let(:outsider) { create(:user) }
+  let!(:child)   { create(:child, family_group: group, name: "そうた") }
+
+  before do
+    create(:user_family_group, user: owner,  family_group: group, role: :owner)
+    create(:user_family_group, user: member, family_group: group, role: :member)
+  end
+
+  describe "GET /family_groups/:family_group_uuid/children (index)" do
+    context "未ログイン" do
+      it "サインイン画面にリダイレクトする" do
+        get family_group_children_path(group)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "オーナー / メンバー" do
+      it "オーナーは 200" do
+        sign_in owner
+        get family_group_children_path(group)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "メンバーは 200" do
+        sign_in member
+        get family_group_children_path(group)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "非メンバー" do
+      it "404（存在を隠す）" do
+        sign_in outsider
+        get family_group_children_path(group)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe "GET /family_groups/:family_group_uuid/children/new (new)" do
+    it "オーナーは 200" do
+      sign_in owner
+      get new_family_group_child_path(group)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "メンバーは認可エラーで root へ" do
+      sign_in member
+      get new_family_group_child_path(group)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe "POST /family_groups/:family_group_uuid/children (create)" do
+    let(:valid_params)   { { child: { name: "あたらしいこども", birthday: "2020-01-01" } } }
+    let(:invalid_params) { { child: { name: "" } } }
+
+    context "オーナー" do
+      before { sign_in owner }
+
+      it "正常系: Child が 1 件作成され一覧へリダイレクト" do
+        expect {
+          post family_group_children_path(group), params: valid_params
+        }.to change(Child, :count).by(1)
+        expect(response).to redirect_to(family_group_children_path(group))
+      end
+
+      it "異常系: name 空は 422 で作成されない" do
+        expect {
+          post family_group_children_path(group), params: invalid_params
+        }.not_to change(Child, :count)
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+
+    context "メンバー" do
+      before { sign_in member }
+
+      it "認可エラーで作成されず root へ" do
+        expect {
+          post family_group_children_path(group), params: valid_params
+        }.not_to change(Child, :count)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "GET /family_groups/:family_group_uuid/children/:uuid/edit (edit)" do
+    it "オーナーは 200" do
+      sign_in owner
+      get edit_family_group_child_path(group, child)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "メンバーは認可エラーで root へ" do
+      sign_in member
+      get edit_family_group_child_path(group, child)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe "PATCH /family_groups/:family_group_uuid/children/:uuid (update)" do
+    context "オーナー" do
+      before { sign_in owner }
+
+      it "正常系: 名前が更新され一覧へリダイレクト" do
+        patch family_group_child_path(group, child), params: { child: { name: "ゆうと" } }
+        expect(child.reload.name).to eq("ゆうと")
+        expect(response).to redirect_to(family_group_children_path(group))
+      end
+
+      it "異常系: name 空は 422 で更新されない" do
+        patch family_group_child_path(group, child), params: { child: { name: "" } }
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(child.reload.name).to eq("そうた")
+      end
+    end
+
+    it "メンバーは認可エラーで root へ" do
+      sign_in member
+      patch family_group_child_path(group, child), params: { child: { name: "ゆうと" } }
+      expect(response).to redirect_to(root_path)
+      expect(child.reload.name).to eq("そうた")
+    end
+  end
+
+  describe "DELETE /family_groups/:family_group_uuid/children/:uuid (destroy)" do
+    it "オーナーは Child を 1 件削除" do
+      sign_in owner
+      expect {
+        delete family_group_child_path(group, child)
+      }.to change(Child, :count).by(-1)
+      expect(response).to redirect_to(family_group_children_path(group))
+    end
+
+    it "メンバーは認可エラーで削除されない" do
+      sign_in member
+      expect {
+        delete family_group_child_path(group, child)
+      }.not_to change(Child, :count)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end

--- a/spec/requests/family_groups_spec.rb
+++ b/spec/requests/family_groups_spec.rb
@@ -1,0 +1,155 @@
+require "rails_helper"
+
+RSpec.describe "FamilyGroups", type: :request do
+  # owner    … グループのオーナー
+  # member   … グループのメンバー
+  # outsider … どのグループにも未所属（= 新規作成が可能なユーザー）
+  let(:group)    { create(:family_group) }
+  let(:owner)    { create(:user) }
+  let(:member)   { create(:user) }
+  let(:outsider) { create(:user) }
+
+  before do
+    create(:user_family_group, user: owner,  family_group: group, role: :owner)
+    create(:user_family_group, user: member, family_group: group, role: :member)
+  end
+
+  describe "GET /family_groups/new (new)" do
+    context "未ログイン" do
+      it "サインイン画面へリダイレクト" do
+        get new_family_group_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    it "未所属ユーザーは 200" do
+      sign_in outsider
+      get new_family_group_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "既にグループ所属のユーザーは認可エラーで root へ" do
+      sign_in owner
+      get new_family_group_path
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe "POST /family_groups (create)" do
+    let(:valid_params)   { { family_group: { name: "あたらしい家族" } } }
+    let(:invalid_params) { { family_group: { name: "" } } }
+
+    context "未所属ユーザー" do
+      before { sign_in outsider }
+
+      it "正常系: Group とオーナーの所属が作成され show へリダイレクト" do
+        expect {
+          post family_groups_path, params: valid_params
+        }.to change(FamilyGroup, :count).by(1)
+         .and change(UserFamilyGroup, :count).by(1)
+        expect(UserFamilyGroup.last).to have_attributes(user: outsider, role: "owner")
+        expect(response).to redirect_to(family_group_path(FamilyGroup.last))
+      end
+
+      it "異常系: name 空は 422 で作成されない" do
+        expect {
+          post family_groups_path, params: invalid_params
+        }.to change(FamilyGroup, :count).by(0).and change(UserFamilyGroup, :count).by(0)
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+
+    it "既に所属のユーザーは認可エラーで作成されず root へ" do
+      sign_in owner
+      expect {
+        post family_groups_path, params: valid_params
+      }.not_to change(FamilyGroup, :count)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe "GET /family_groups/:uuid (show)" do
+    context "未ログイン" do
+      it "サインイン画面へリダイレクト" do
+        get family_group_path(group)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    it "オーナーは 200" do
+      sign_in owner
+      get family_group_path(group)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "メンバーは 200" do
+      sign_in member
+      get family_group_path(group)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "非メンバーは 404" do
+      sign_in outsider
+      get family_group_path(group)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "PATCH /family_groups/:uuid (update)" do
+    context "オーナー" do
+      before { sign_in owner }
+
+      it "正常系: 名前が更新され show へリダイレクト" do
+        patch family_group_path(group), params: { family_group: { name: "新しい名前" } }
+        expect(group.reload.name).to eq("新しい名前")
+        expect(response).to redirect_to(family_group_path(group))
+      end
+
+      it "異常系: name 空は 422 で更新されない" do
+        # 既知バグ: update 失敗時に `render :edit` するが app/views/family_groups/edit.html.erb が
+        # 存在せず ActionView::MissingTemplate で 500 になる。修正後にこの pending を外す。
+        pending "既知バグ: edit.html.erb 不在で update 失敗時に 500 になる（要修正）"
+        patch family_group_path(group), params: { family_group: { name: "" } }
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(group.reload.name).to eq("テスト家族")
+      end
+    end
+
+    it "メンバーは認可エラーで更新されず root へ" do
+      sign_in member
+      patch family_group_path(group), params: { family_group: { name: "新しい名前" } }
+      expect(response).to redirect_to(root_path)
+      expect(group.reload.name).to eq("テスト家族")
+    end
+
+    it "非メンバーは 404" do
+      sign_in outsider
+      patch family_group_path(group), params: { family_group: { name: "新しい名前" } }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "DELETE /family_groups/:uuid (destroy)" do
+    it "オーナーは Group を削除し mypage へリダイレクト" do
+      sign_in owner
+      expect {
+        delete family_group_path(group)
+      }.to change(FamilyGroup, :count).by(-1)
+      expect(response).to redirect_to(mypage_path)
+    end
+
+    it "メンバーは認可エラーで削除されない" do
+      sign_in member
+      expect {
+        delete family_group_path(group)
+      }.not_to change(FamilyGroup, :count)
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "非メンバーは 404" do
+      sign_in outsider
+      delete family_group_path(group)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/reactions_spec.rb
+++ b/spec/requests/reactions_spec.rb
@@ -1,0 +1,103 @@
+require "rails_helper"
+
+RSpec.describe "Reactions", type: :request do
+  # owner   … 投稿者（自分の投稿にはリアクション不可）
+  # reactor … リアクションする他人
+  let(:owner)   { create(:user) }
+  let(:reactor) { create(:user) }
+  # 公開掲示板に出ている他人の投稿
+  let(:memory)  { create(:memory, user: owner, visibility: :published) }
+
+  describe "POST /public_memories/:public_memory_uuid/reactions (create)" do
+    let(:params) { { reaction_type: "heart" } }
+
+    context "未ログイン" do
+      it "サインイン画面にリダイレクト + Reaction は作成されない" do
+        expect {
+          post public_memory_reactions_path(memory), params: params
+        }.not_to change(Reaction, :count)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "ログイン済み・他人の公開投稿" do
+      before { sign_in reactor }
+
+      it "Reaction が 1 件作成される（html はリダイレクト）" do
+        expect {
+          post public_memory_reactions_path(memory), params: params
+        }.to change(Reaction, :count).by(1)
+        expect(response).to redirect_to(public_memory_path(memory))
+      end
+
+      it "turbo_stream でも作成される" do
+        expect {
+          post public_memory_reactions_path(memory), params: params, as: :turbo_stream
+        }.to change(Reaction, :count).by(1)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "同じリアクションを重複して押しても増えない（uniqueness）" do
+        create(:reaction, user: reactor, memory: memory, reaction_type: :heart)
+        expect {
+          post public_memory_reactions_path(memory), params: params
+        }.not_to change(Reaction, :count)
+      end
+
+      it "無効な reaction_type は作成されず掲示板へリダイレクト" do
+        expect {
+          post public_memory_reactions_path(memory), params: { reaction_type: "invalid_type" }
+        }.not_to change(Reaction, :count)
+        expect(response).to redirect_to(public_memory_path(memory))
+      end
+    end
+
+    context "自分の投稿にはリアクションできない" do
+      before { sign_in owner }
+
+      it "認可エラーで作成されず root へリダイレクト" do
+        expect {
+          post public_memory_reactions_path(memory), params: params
+        }.not_to change(Reaction, :count)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "非公開(private_only)投稿にはリアクションできない" do
+      let(:private_memory) { create(:memory, user: owner, visibility: :private_only) }
+      before { sign_in reactor }
+
+      it "認可エラーで作成されず root へリダイレクト" do
+        expect {
+          post public_memory_reactions_path(private_memory), params: params
+        }.not_to change(Reaction, :count)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "DELETE /public_memories/:public_memory_uuid/reactions/:reaction_type (destroy)" do
+    context "未ログイン" do
+      before { create(:reaction, user: reactor, memory: memory, reaction_type: :heart) }
+
+      it "サインイン画面にリダイレクト" do
+        delete public_memory_reaction_path(memory, "heart")
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "ログイン済み・自分のリアクション" do
+      before do
+        sign_in reactor
+        create(:reaction, user: reactor, memory: memory, reaction_type: :heart)
+      end
+
+      it "Reaction が 1 件削除される" do
+        expect {
+          delete public_memory_reaction_path(memory, "heart")
+        }.to change(Reaction, :count).by(-1)
+        expect(response).to redirect_to(public_memory_path(memory))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
カバレッジが 0% だったコントローラにリクエストスペックを追加し、ライン カバレッジを
46.3% → 62.6%（+16.3pt）に改善。あわせて未修正の実バグを1件検出した。

## 含まれる変更
### リクエストスペック追加（コントローラ単位）
- `reactions_controller`（0% → 89.7%）：作成/削除の正常系・認可（自分の投稿/非公開不可）・重複・無効type
- `children_controller`（0% → 100%）：index/new/create/edit/update/destroy の認可マトリクス（非メンバー404 / メンバー閲覧のみ / オーナー全操作）
- `family_groups_controller`（0% → 94.1%）：new/create/show/update/destroy の認可（未所属のみ作成可 / オーナーのみ更新・削除 / 非メンバー404）

### 検出した既知バグ（本PRでは未修正・pending で記録）
- `FamilyGroupsController#update` がバリデーション失敗時に `render :edit` するが
  `app/views/family_groups/edit.html.erb` が存在せず **500 (MissingTemplate)** になる
- 該当テストを `pending` 化して可視化（修正後に pending を外すと検知できる）

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| spec/requests/reactions_spec.rb | 新規 | reactions_controller のカバレッジ |
| spec/requests/children_spec.rb | 新規 | children_controller のカバレッジ |
| spec/requests/family_groups_spec.rb | 新規 | family_groups_controller のカバレッジ + 既知バグの pending 記録 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 子ども、家族グループ、リアクションの主要操作に対するリクエストテストを追加しました。
  * ログイン状態、権限、重複操作、無効入力、非公開コンテンツの制御などを幅広く検証しています。
  * 作成・更新・削除時の遷移やステータスコードの期待値も整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->