### PR TITLE
 家族グループの編集画面を追加＋テスト実装

### DIFF
--- a/app/views/family_groups/_form.html.erb
+++ b/app/views/family_groups/_form.html.erb
@@ -1,0 +1,20 @@
+<%# 家族グループの新規作成・編集で共有するフォーム。
+    locals: family_group（対象）/ cancel_path（キャンセル先）/ submit_label（送信ボタン文言）。
+    form_with は未保存なら create、保存済みなら update に自動で振り分ける。 %>
+<%= form_with model: family_group do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+
+  <div class="form-control gap-1">
+    <%= f.label :name, class: "label py-0" do %>
+      <span class="label-text font-semibold text-xs tracking-wide uppercase text-base-content/60"><%= t('mypage.family_group.form.name_label') %></span>
+    <% end %>
+    <%= f.text_field :name,
+          placeholder: t('mypage.family_group.form.name_placeholder'),
+          class: "input input-bordered input-sm bg-base-200/50 focus:bg-base-100 focus:input-primary transition-all duration-200 w-full" %>
+  </div>
+
+  <div class="flex justify-end gap-2 pt-1 border-t border-base-200">
+    <%= link_to t('helpers.submit.cancel'), cancel_path, class: "btn btn-ghost btn-sm" %>
+    <%= f.submit submit_label, class: "btn btn-primary btn-sm px-6" %>
+  </div>
+<% end %>

--- a/app/views/family_groups/edit.html.erb
+++ b/app/views/family_groups/edit.html.erb
@@ -12,8 +12,8 @@
         </svg>
       </div>
       <div>
-        <h1 class="text-xl font-bold tracking-tight leading-tight"><%= t('mypage.family_group.new.title') %></h1>
-        <p class="text-base-content/50 text-xs"><%= t('mypage.family_group.new.subtitle') %></p>
+        <h1 class="text-xl font-bold tracking-tight leading-tight"><%= t('mypage.family_group.edit.title') %></h1>
+        <p class="text-base-content/50 text-xs"><%= t('mypage.family_group.edit.subtitle') %></p>
       </div>
     </div>
 
@@ -21,8 +21,8 @@
       <div class="card-body p-6 gap-4">
         <%= render "form",
               family_group: @family_group,
-              cancel_path: mypage_path,
-              submit_label: t("mypage.family_group.new.create_group") %>
+              cancel_path: family_group_path(@family_group),
+              submit_label: t("mypage.family_group.edit.update_group") %>
       </div>
     </div>
   </div>

--- a/app/views/family_groups/show.html.erb
+++ b/app/views/family_groups/show.html.erb
@@ -19,7 +19,7 @@
           <% if policy(@family_group).update? %>
             <%= link_to edit_family_group_path(@family_group),
                   class: "btn btn-ghost btn-xs btn-circle",
-                  aria: { label: "グループ名を編集" } do %>
+                  aria: { label: t("mypage.family_group.show.edit_name") } do %>
               <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-base-content/60" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
               </svg>

--- a/app/views/family_groups/show.html.erb
+++ b/app/views/family_groups/show.html.erb
@@ -14,7 +14,18 @@
         </svg>
       </div>
       <div>
-        <h1 class="text-xl font-bold tracking-tight leading-tight"><%= @family_group.name %></h1>
+        <div class="flex items-center gap-2">
+          <h1 class="text-xl font-bold tracking-tight leading-tight"><%= @family_group.name %></h1>
+          <% if policy(@family_group).update? %>
+            <%= link_to edit_family_group_path(@family_group),
+                  class: "btn btn-ghost btn-xs btn-circle",
+                  aria: { label: "グループ名を編集" } do %>
+              <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-base-content/60" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
+              </svg>
+            <% end %>
+          <% end %>
+        </div>
         <p class="text-base-content/50 text-xs"><%= t('mypage.family_group.member_count', count: @family_group.users.count) %></p>
       </div>
     </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -140,12 +140,19 @@ ja:
       not_joined: グループに参加していません
       not_joined_subtitle: 家族グループに参加して、ミニメモリを共有しましょう
       create_group: グループを作成
+      form:
+        name_label: グループ名
+        name_placeholder: グループ名を入力 (例：田中家、山田ファミリー)
       new:
         title: 家族グループ新規作成
         subtitle: 家族グループを作成して、ミニメモリを共有しましょう
         name_label: グループ名
         name_placeholder: グループ名を入力 (例：田中家、山田ファミリー)
         create_group: グループを作成
+      edit:
+        title: 家族グループの編集
+        subtitle: グループ名を変更できます
+        update_group: 変更を保存
       show:
         invitation: 招待リンク
         copy: コピー

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -154,6 +154,7 @@ ja:
         subtitle: グループ名を変更できます
         update_group: 変更を保存
       show:
+        edit_name: グループ名を編集
         invitation: 招待リンク
         copy: コピー
         invitation_expires_at: 有効期限

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,7 @@ Rails.application.routes.draw do
   resources :family_memories, param: :uuid, only: %i[index show]
 
   # 家族グループ - uuidをURLパラメータとして使用するため、param: :uuidを指定
-  resources :family_groups, param: :uuid, only: %i[new create update show destroy] do
+  resources :family_groups, param: :uuid, only: %i[new create edit update show destroy] do
     # メンバーシップ操作（役割変更・脱退）。member 中間テーブルのため id は数値 ID。
     resources :user_family_groups, only: %i[update destroy]
 

--- a/spec/requests/family_groups_spec.rb
+++ b/spec/requests/family_groups_spec.rb
@@ -35,6 +35,33 @@ RSpec.describe "FamilyGroups", type: :request do
     end
   end
 
+  describe "GET /family_groups/:uuid/edit (edit)" do
+    context "未ログイン" do
+      it "サインイン画面へリダイレクト" do
+        get edit_family_group_path(group)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    it "オーナーは 200" do
+      sign_in owner
+      get edit_family_group_path(group)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "メンバーは認可エラーで root へ" do
+      sign_in member
+      get edit_family_group_path(group)
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "非メンバーは 404" do
+      sign_in outsider
+      get edit_family_group_path(group)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
   describe "POST /family_groups (create)" do
     let(:valid_params)   { { family_group: { name: "あたらしい家族" } } }
     let(:invalid_params) { { family_group: { name: "" } } }
@@ -106,9 +133,6 @@ RSpec.describe "FamilyGroups", type: :request do
       end
 
       it "異常系: name 空は 422 で更新されない" do
-        # 既知バグ: update 失敗時に `render :edit` するが app/views/family_groups/edit.html.erb が
-        # 存在せず ActionView::MissingTemplate で 500 になる。修正後にこの pending を外す。
-        pending "既知バグ: edit.html.erb 不在で update 失敗時に 500 になる（要修正）"
         patch family_group_path(group), params: { family_group: { name: "" } }
         expect(response).to have_http_status(:unprocessable_content)
         expect(group.reload.name).to eq("テスト家族")


### PR DESCRIPTION
## 概要
家族グループに編集画面を実装。それに合わせ、その部分のテストを実装。

## 含まれる変更
### 編集機能の追加
- ルートに `:edit` を追加
- `show` のグループ名の横に、オーナーのみ表示の編集リンク（鉛筆アイコン）を追加
- `edit.html.erb` を新規作成
- 新規/編集フォームを `_form.html.erb` に共通化（`form_with model:` が create/update を自動振り分け）
- i18n（`mypage.family_group.form` / `edit`）を追加

### テスト
- `family_groups_controller` の GET edit リクエストスペックを追加

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| config/routes.rb | 修正 | `:edit` ルート追加 |
| config/locales/views/ja.yml | 修正 | 共通フォーム/edit の翻訳追加 |
| app/views/family_groups/_form.html.erb | 新規 | new/edit 共通フォーム |
| app/views/family_groups/new.html.erb | 修正 | 共通 `_form` を使う形に置換 |
| app/views/family_groups/edit.html.erb | 新規 | 編集画面 |
| app/views/family_groups/show.html.erb | 修正 | オーナー用の編集リンク追加 |
| spec/requests/family_groups_spec.rb | 修正 | edit スペック追加・pending 解除 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 家族グループの作成・編集で共通のフォームが使えるようになりました。
  * 家族グループ詳細画面から、権限がある場合に名前の編集へ進めるリンクが表示されます。

* **改善**
  * 新規作成・編集画面の表示を整理し、キャンセル導線や送信ボタンの文言をわかりやすくしました。
  * 家族グループ編集画面を追加し、画面内の文言も統一しました。

* **バグ修正**
  * 家族グループ編集画面に関する既知の問題を解消し、更新時の入力エラー表示が正しく扱われるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->