### PR TITLE
3つのコントローラーのリクエストスペックを追加

### DIFF
--- a/spec/requests/family_memories_spec.rb
+++ b/spec/requests/family_memories_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe "FamilyMemories", type: :request do
+  let(:group)    { create(:family_group) }
+  let(:poster)   { create(:user) } # 投稿者（グループメンバー）
+  let(:viewer)   { create(:user) } # 同じグループの閲覧者
+  let(:outsider) { create(:user) } # 別グループ未所属の第三者
+
+  before do
+    create(:user_family_group, user: poster, family_group: group, role: :owner)
+    create(:user_family_group, user: viewer, family_group: group, role: :member)
+  end
+
+  describe "GET /family_memories (index)" do
+    context "未ログイン" do
+      it "サインイン画面へリダイレクト" do
+        get family_memories_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    it "ログイン済みユーザーは 200" do
+      sign_in viewer
+      get family_memories_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /family_memories/:uuid (show)" do
+    let(:unlisted_memory)  { create(:memory, user: poster, visibility: :unlisted) }
+    let(:published_memory) { create(:memory, user: poster, visibility: :published) }
+    let(:private_memory)   { create(:memory, user: poster, visibility: :private_only) }
+
+    context "未ログイン" do
+      it "サインイン画面へリダイレクト" do
+        get family_memory_path(unlisted_memory)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "同じグループのメンバー" do
+      before { sign_in viewer }
+
+      it "unlisted な家族の投稿は 200" do
+        get family_memory_path(unlisted_memory)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "published な家族の投稿は 200" do
+        get family_memory_path(published_memory)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "private_only な投稿は認可エラーで root へ" do
+        get family_memory_path(private_memory)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    it "別グループの第三者は unlisted でも認可エラーで root へ" do
+      sign_in outsider
+      get family_memory_path(unlisted_memory)
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "存在しない uuid は 404" do
+      sign_in viewer
+      get family_memory_path("nonexistent-uuid")
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/family_memories_spec.rb
+++ b/spec/requests/family_memories_spec.rb
@@ -24,6 +24,21 @@ RSpec.describe "FamilyMemories", type: :request do
       get family_memories_path
       expect(response).to have_http_status(:ok)
     end
+
+    it "家族の unlisted/published のみ表示し、private_only と家族外の投稿は除外する" do
+      visible_published = create(:memory, user: poster,   visibility: :published,    title: "家族の公開投稿")
+      visible_unlisted  = create(:memory, user: poster,   visibility: :unlisted,     title: "家族の限定投稿")
+      hidden_private    = create(:memory, user: poster,   visibility: :private_only, title: "家族の非公開投稿")
+      outsider_post     = create(:memory, user: outsider, visibility: :published,    title: "家族外の公開投稿")
+
+      sign_in viewer
+      get family_memories_path
+
+      expect(response.body).to include(visible_published.title)
+      expect(response.body).to include(visible_unlisted.title)
+      expect(response.body).not_to include(hidden_private.title)
+      expect(response.body).not_to include(outsider_post.title)
+    end
   end
 
   describe "GET /family_memories/:uuid (show)" do

--- a/spec/requests/invitations_spec.rb
+++ b/spec/requests/invitations_spec.rb
@@ -1,0 +1,113 @@
+require "rails_helper"
+
+RSpec.describe "Invitations", type: :request do
+  let(:group)    { create(:family_group) }
+  let(:owner)    { create(:user) }
+  let(:member)   { create(:user) }
+  let(:outsider) { create(:user) } # どのグループにも未所属（参加可能なユーザー）
+
+  before do
+    create(:user_family_group, user: owner,  family_group: group, role: :owner)
+    create(:user_family_group, user: member, family_group: group, role: :member)
+  end
+
+  describe "POST /invitations (create = 招待リンク発行)" do
+    context "未ログイン" do
+      it "サインイン画面へリダイレクト" do
+        post invitations_path, params: { family_group_id: group.id }
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    it "オーナーは招待を発行でき、グループ詳細へリダイレクト" do
+      sign_in owner
+      expect {
+        post invitations_path, params: { family_group_id: group.id }
+      }.to change(Invitation, :count).by(1)
+      expect(response).to redirect_to(family_group_path(group))
+    end
+
+    it "メンバーは認可エラーで発行されず root へ" do
+      sign_in member
+      expect {
+        post invitations_path, params: { family_group_id: group.id }
+      }.not_to change(Invitation, :count)
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "非メンバーは認可エラーで発行されず root へ" do
+      sign_in outsider
+      expect {
+        post invitations_path, params: { family_group_id: group.id }
+      }.not_to change(Invitation, :count)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe "GET /invitations/:token (show = 招待リンク閲覧)" do
+    let(:invitation) { create(:invitation, family_group: group) }
+
+    it "有効なトークン + 未所属ユーザーは 200" do
+      sign_in outsider
+      get invitation_path(invitation.token)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "未ログインはログイン要求でサインイン画面へ" do
+      get invitation_path(invitation.token)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "既にグループ所属のユーザーは mypage へリダイレクト" do
+      sign_in member
+      get invitation_path(invitation.token)
+      expect(response).to redirect_to(mypage_path)
+    end
+
+    it "期限切れトークンは root へリダイレクト" do
+      invitation.update_column(:expires_at, 1.day.ago)
+      sign_in outsider
+      get invitation_path(invitation.token)
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "存在しないトークンは root へリダイレクト" do
+      sign_in outsider
+      get invitation_path("nonexistent-token")
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe "POST /invitations/:token/join (join = 参加)" do
+    let(:invitation) { create(:invitation, family_group: group) }
+
+    it "未所属ユーザーは参加でき、mypage へリダイレクト" do
+      sign_in outsider
+      expect {
+        post join_invitation_path(invitation.token)
+      }.to change(UserFamilyGroup, :count).by(1)
+      expect(outsider.reload.family_groups).to include(group)
+      expect(response).to redirect_to(mypage_path)
+    end
+
+    it "既に所属のユーザーは参加できず mypage へリダイレクト" do
+      sign_in member
+      expect {
+        post join_invitation_path(invitation.token)
+      }.not_to change(UserFamilyGroup, :count)
+      expect(response).to redirect_to(mypage_path)
+    end
+
+    it "未ログインはサインイン画面へ" do
+      post join_invitation_path(invitation.token)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "期限切れトークンは root へリダイレクト" do
+      invitation.update_column(:expires_at, 1.day.ago)
+      sign_in outsider
+      post join_invitation_path(invitation.token)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end

--- a/spec/requests/invitations_spec.rb
+++ b/spec/requests/invitations_spec.rb
@@ -109,5 +109,13 @@ RSpec.describe "Invitations", type: :request do
       post join_invitation_path(invitation.token)
       expect(response).to redirect_to(root_path)
     end
+
+    it "存在しないトークンは root へリダイレクトし、参加しない" do
+      sign_in outsider
+      expect {
+        post join_invitation_path("nonexistent-token")
+      }.not_to change(UserFamilyGroup, :count)
+      expect(response).to redirect_to(root_path)
+    end
   end
 end

--- a/spec/requests/user_family_groups_spec.rb
+++ b/spec/requests/user_family_groups_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+RSpec.describe "UserFamilyGroups", type: :request do
+  # owner    … グループのオーナー
+  # co_owner … 2人目のオーナー（降格テスト用）
+  # member   … 一般メンバー
+  # outsider … 非メンバー（存在隠蔽で 404 になるべきユーザー）
+  let(:group)    { create(:family_group) }
+  let(:owner)    { create(:user) }
+  let(:co_owner) { create(:user) }
+  let(:member)   { create(:user) }
+  let(:outsider) { create(:user) }
+
+  let!(:owner_membership)    { create(:user_family_group, user: owner,    family_group: group, role: :owner) }
+  let!(:co_owner_membership) { create(:user_family_group, user: co_owner, family_group: group, role: :owner) }
+  let!(:member_membership)   { create(:user_family_group, user: member,   family_group: group, role: :member) }
+
+  describe "PATCH /family_groups/:uuid/user_family_groups/:id (update = 役割変更)" do
+    context "未ログイン" do
+      it "サインイン画面へリダイレクト" do
+        patch family_group_user_family_group_path(group, member_membership), params: { role: "owner" }
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "オーナー" do
+      before { sign_in owner }
+
+      it "メンバーをオーナーに昇格でき、show へリダイレクト" do
+        patch family_group_user_family_group_path(group, member_membership), params: { role: "owner" }
+        expect(member_membership.reload.role).to eq("owner")
+        expect(response).to redirect_to(family_group_path(group))
+      end
+
+      it "別のオーナーをメンバーに降格できる" do
+        patch family_group_user_family_group_path(group, co_owner_membership), params: { role: "member" }
+        expect(co_owner_membership.reload.role).to eq("member")
+        expect(response).to redirect_to(family_group_path(group))
+      end
+    end
+
+    it "メンバーは認可エラーで変更されず root へ" do
+      sign_in member
+      patch family_group_user_family_group_path(group, co_owner_membership), params: { role: "member" }
+      expect(response).to redirect_to(root_path)
+      expect(co_owner_membership.reload.role).to eq("owner")
+    end
+
+    it "非メンバーは 404" do
+      sign_in outsider
+      patch family_group_user_family_group_path(group, member_membership), params: { role: "owner" }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "DELETE /family_groups/:uuid/user_family_groups/:id (destroy = 脱退・除名)" do
+    context "未ログイン" do
+      it "サインイン画面へリダイレクト" do
+        delete family_group_user_family_group_path(group, member_membership)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    it "メンバーは自分自身を脱退でき、mypage へリダイレクト" do
+      sign_in member
+      expect {
+        delete family_group_user_family_group_path(group, member_membership)
+      }.to change(UserFamilyGroup, :count).by(-1)
+      expect(response).to redirect_to(mypage_path)
+    end
+
+    it "オーナーは他メンバーを除名でき、show へリダイレクト" do
+      sign_in owner
+      expect {
+        delete family_group_user_family_group_path(group, member_membership)
+      }.to change(UserFamilyGroup, :count).by(-1)
+      expect(response).to redirect_to(family_group_path(group))
+    end
+
+    it "メンバーは他メンバーを除名できず root へ" do
+      sign_in member
+      expect {
+        delete family_group_user_family_group_path(group, co_owner_membership)
+      }.not_to change(UserFamilyGroup, :count)
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "非メンバーは 404" do
+      sign_in outsider
+      delete family_group_user_family_group_path(group, member_membership)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- テスト未整備だったコントローラーのうち、認可・分岐ロジックが複雑な3つにリクエストスペックを追加
- いずれも「正常系 / 異常系 / 認可（未ログイン・権限なし・非メンバー）」の3軸でカバー

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| spec/requests/user_family_groups_spec.rb | 新規 | 役割変更・脱退・除名の認可マトリクスを検証 |
| spec/requests/invitations_spec.rb | 新規 | 招待リンクの発行・閲覧・参加フローを検証 |
| spec/requests/family_memories_spec.rb | 新規 | 家族フィードと family_show? の認可を検証 |

## 実装のポイント
- **user_family_groups（10例）:** `update?`=owner のみ / `destroy?`=本人 or owner の分岐、非メンバーは `policy_scope` により 404 になることを確認
- **invitations（13例）:** owner 限定の発行認可に加え、期限切れ・未ログイン・二重参加を含む `set_and_validate_invitation` の分岐を網羅
- **family_memories（8例）:** `family_show?` の3条件（ログイン・`unlisted`/`published`・同一家族グループ）を分岐ごとに検証し、`private_only` や第三者の拒否を確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 予定されている操作ごとのアクセス制御と表示条件を確認するリクエストテストを追加しました。
  * 家族の思い出一覧・詳細、招待の作成/閲覧/参加、ユーザー所属グループの変更/退会について、ログイン状態や権限ごとの挙動を網羅しています。
  * 存在しない情報や権限外アクセス時のリダイレクト、404応答も検証するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->