### PR TITLE
６つのコントローラーのリクエストスペックを追加

### DIFF
--- a/spec/requests/api/memory_games_spec.rb
+++ b/spec/requests/api/memory_games_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe "Api::MemoryGames", type: :request do
+  let(:user) { create(:user) }
+
+  describe "GET /api/memory_game (show)" do
+    context "未ログイン" do
+      it "サインイン画面へリダイレクト" do
+        get api_memory_game_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "ログイン済み" do
+      before { sign_in user }
+
+      it "画像付き投稿が 0 件なら sufficient: false と必要枚数を返す" do
+        get api_memory_game_path
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body["sufficient"]).to be(false)
+        expect(body["needed"]).to eq(2)
+      end
+
+      it "画像付き投稿が 1 件なら sufficient: false（残り1枚）" do
+        create(:memory, user: user)
+        get api_memory_game_path
+        body = response.parsed_body
+        expect(body["sufficient"]).to be(false)
+        expect(body["needed"]).to eq(1)
+      end
+
+      it "画像付き投稿が 2 件以上なら sufficient: true とカードを返す" do
+        create_list(:memory, 3, user: user)
+        get api_memory_game_path
+        body = response.parsed_body
+        expect(body["sufficient"]).to be(true)
+        expect(body["cards"].size).to eq(3)
+        expect(body["cards"].first.keys).to include("id", "uuid", "title", "description", "memory_date", "url")
+      end
+
+      it "他人の投稿はカードに含めない（自分の投稿のみ対象）" do
+        create_list(:memory, 2, user: user)
+        create_list(:memory, 5, user: create(:user)) # 他人の投稿
+        get api_memory_game_path
+        body = response.parsed_body
+        expect(body["cards"].size).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "Dashboard", type: :request do
+  let(:user) { create(:user) }
+
+  it "ログイン済みユーザーは / で dashboard が 200" do
+    sign_in user
+    get root_path
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "自分の最近の投稿が表示される" do
+    memory = create(:memory, user: user, title: "ダッシュボードに出る投稿")
+    sign_in user
+    get root_path
+    expect(response.body).to include(memory.title)
+  end
+end

--- a/spec/requests/memory_games_spec.rb
+++ b/spec/requests/memory_games_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe "MemoryGames", type: :request do
+  let(:user) { create(:user) }
+
+  it "未ログインはサインイン画面へリダイレクト" do
+    get memory_game_path
+    expect(response).to redirect_to(new_user_session_path)
+  end
+
+  it "ログイン済みユーザーは 200" do
+    sign_in user
+    get memory_game_path
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/requests/mypages_spec.rb
+++ b/spec/requests/mypages_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe "Mypages", type: :request do
+  let(:user) { create(:user) }
+
+  it "未ログインはサインイン画面へリダイレクト" do
+    get mypage_path
+    expect(response).to redirect_to(new_user_session_path)
+  end
+
+  it "ログイン済みユーザーは 200" do
+    sign_in user
+    get mypage_path
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/requests/public_memories_spec.rb
+++ b/spec/requests/public_memories_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe "PublicMemories", type: :request do
+  let(:author) { create(:user) }
+
+  describe "GET /public_memories (index)" do
+    it "未ログインでも 200" do
+      get public_memories_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "published のみ一覧に表示し、private_only / unlisted は除外する" do
+      published = create(:memory, user: author, visibility: :published,    title: "公開された投稿")
+      private_o = create(:memory, user: author, visibility: :private_only, title: "非公開の投稿")
+      unlisted  = create(:memory, user: author, visibility: :unlisted,     title: "限定公開の投稿")
+
+      get public_memories_path
+
+      expect(response.body).to include(published.title)
+      expect(response.body).not_to include(private_o.title)
+      expect(response.body).not_to include(unlisted.title)
+    end
+  end
+
+  describe "GET /public_memories/:uuid (show)" do
+    it "published な投稿は未ログインでも 200" do
+      memory = create(:memory, user: author, visibility: :published)
+      get public_memory_path(memory)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "private_only な投稿は一覧へリダイレクト" do
+      memory = create(:memory, user: author, visibility: :private_only)
+      get public_memory_path(memory)
+      expect(response).to redirect_to(public_memories_path)
+    end
+
+    it "unlisted な投稿は一覧へリダイレクト" do
+      memory = create(:memory, user: author, visibility: :unlisted)
+      get public_memory_path(memory)
+      expect(response).to redirect_to(public_memories_path)
+    end
+
+    it "存在しない uuid は一覧へリダイレクト" do
+      get public_memory_path("nonexistent-uuid")
+      expect(response).to redirect_to(public_memories_path)
+    end
+  end
+end

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "StaticPages", type: :request do
+  it "GET / (top) は未ログインでも 200" do
+    get root_path
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "GET /contact は 200" do
+    get contact_path
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "GET /terms は 200" do
+    get terms_path
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "GET /privacy は 200" do
+    get privacy_path
+    expect(response).to have_http_status(:ok)
+  end
+end


### PR DESCRIPTION
## 概要
- テスト未整備だったコントローラー6つにリクエストスペックを追加

## 関連 Issue
（あれば記入）

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| spec/requests/public_memories_spec.rb | 新規 | 掲示板の公開範囲フィルタと非公開リソースのリダイレクトを検証 |
| spec/requests/api/memory_games_spec.rb | 新規 | 神経衰弱カード API の JSON 応答（不足/充足の分岐）を検証 |
| spec/requests/static_pages_spec.rb | 新規 | top/contact/terms/privacy の表示を検証 |
| spec/requests/dashboard_spec.rb | 新規 | ログイン時の dashboard 表示と最近の投稿を検証 |
| spec/requests/mypages_spec.rb | 新規 | 認証リダイレクトと表示を検証 |
| spec/requests/memory_games_spec.rb | 新規 | 認証リダイレクトと表示を検証 |

## 実装のポイント
- **public_memories:** `publicly_available`（published のみ）を本文で検証、`private_only`/`unlisted` は `memory_not_found` で一覧へリダイレクト
- **api/memory_games:** カード不足（0件/1件）と充足（2件以上）の分岐、JSON 構造、`policy_scope` による本人投稿のみ対象を確認
- **dashboard:** `authenticated :user` 制約により `/` が dashboard#top に割り当てられる挙動をログイン状態で検証

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 各ページの表示・認証まわりの挙動を確認するリクエストテストを追加しました。
  * ホーム、ダッシュボード、マイページ、公開一覧、メモリーゲームのアクセス制御と表示内容を検証しています。
  * 公開投稿のみが一覧や詳細に表示されること、ログイン状態に応じた遷移やレスポンスが正しいことを確認するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->