### PR TITLE
ゲーム機能の導線ラベルを「ゲーム」に統一

### DIFF
--- a/app/views/shared/_drawer_menu.html.erb
+++ b/app/views/shared/_drawer_menu.html.erb
@@ -9,7 +9,7 @@
         <ul>
           <li><%= link_to t('drawer.list.create_memory'), new_memory_path %></li>
           <li><%= link_to t('drawer.list.memory_index'), memories_path %></li>
-          <li><%= link_to t('drawer.list.enjoy'), memory_game_path %></li>
+          <li><%= link_to t('drawer.list.game'), memory_game_path %></li>
         </ul>
       </details>
     </li>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -42,14 +42,14 @@
       <% end %>
 
 
-      <%# 楽しむボタン %>
+      <%# ゲームボタン %>
       <%= link_to memory_game_path, class: "flex flex-col items-center justify-center text-xs #{active_if("memory_games")}" do %>
         <span class="text-xl">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 fill-current" viewBox="0 0 24 24">
               <path d="M21.58,16.09l-1.09-7.66C20.21,6.46,18.52,5,16.53,5H7.47C5.48,5,3.79,6.46,3.51,8.43l-1.09,7.66C2.2,17.63,3.39,19,4.94,19h0c0.68,0,1.32-0.27,1.8-0.75L9,16h6l2.25,2.25c0.48,0.48,1.13,0.75,1.8,0.75h0C20.61,19,21.8,17.63,21.58,16.09z M11,11H9v2H8v-2H6v-1h2V8h1v2h2V11z M15,10c-0.55,0-1-0.45-1-1c0-0.55,0.45-1,1-1s1,0.45,1,1C16,9.55,15.55,10,15,10z M17,13c-0.55,0-1-0.45-1-1c0-0.55,0.45-1,1-1s1,0.45,1,1C18,12.55,17.55,13,17,13z"/>
           </svg>
         </span>
-        <span><%= t('footer.enjoy') %></span>
+        <span><%= t('footer.game') %></span>
       <% end %>
     </div>
   </footer>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -190,7 +190,7 @@ ja:
     new_memory: 新規投稿
     family_memory: 家族メモリ
     board: 掲示板
-    enjoy: 楽しむ
+    game: ゲーム
   drawer:
     summary:
       mini_memory: 私のミニメモリ
@@ -201,7 +201,7 @@ ja:
     list:
       create_memory: 新規投稿
       memory_index: ミニメモリ一覧
-      enjoy: 楽しむ
+      game: ゲーム
       family_memory_index: 家族メモリ一覧
       family_group_settings: 家族グループ設定
       board: 掲示板


### PR DESCRIPTION
## 概要
- ゲーム機能への導線ラベルが「楽しむ」（フッター・ドロワー）と「ゲーム」（ダッシュボード）で揺れていたため「ゲーム」に統一
- i18n キーも意味に合わせて `enjoy` → `game` にリネーム

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| config/locales/views/ja.yml | 修正 | `footer.enjoy`→`footer.game` / `drawer.list.enjoy`→`drawer.list.game`（値も「ゲーム」に） |
| app/views/shared/_footer.html.erb | 修正 | ラベル参照キーの更新・コメント修正 |
| app/views/shared/_drawer_menu.html.erb | 修正 | ラベル参照キーの更新 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ドロワーメニューとフッターのゲーム関連ラベルを「楽しむ」から「ゲーム」に統一しました。
  * 日本語表示の文言も更新され、画面上の表記がより分かりやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->