### PR TITLE
LINEログインを自前ストラテジ化し整理

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gem "devise"
 gem "devise-i18n"
 
 # Omniauth - サードパーティ認証の統合
-gem "omniauth-line"
+# LINE ログインは lib/omniauth/strategies/line.rb で自前実装（旧 gem "omniauth-line" は未メンテのため撤去）
 gem "omniauth-rails_csrf_protection"
 
 gem "omniauth-google-oauth2"

--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gem "devise"
 gem "devise-i18n"
 
 # Omniauth - サードパーティ認証の統合
-# LINE ログインは lib/omniauth/strategies/line.rb で自前実装（旧 gem "omniauth-line" は未メンテのため撤去）
+gem "omniauth-oauth2"
 gem "omniauth-rails_csrf_protection"
 
 gem "omniauth-google-oauth2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -552,6 +552,7 @@ DEPENDENCIES
   meta-tags
   minitest (~> 5.25)
   omniauth-google-oauth2
+  omniauth-oauth2
   omniauth-rails_csrf_protection
   pg (~> 1.1)
   puma (>= 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,9 +285,6 @@ GEM
       oauth2 (~> 2.0)
       omniauth (~> 2.0)
       omniauth-oauth2 (~> 1.8)
-    omniauth-line (0.1.0)
-      json (>= 2.3.0)
-      omniauth-oauth2 (~> 1.3)
     omniauth-oauth2 (1.9.0)
       oauth2 (>= 2.0.2, < 3)
       omniauth (~> 2.0)
@@ -555,7 +552,6 @@ DEPENDENCIES
   meta-tags
   minitest (~> 5.25)
   omniauth-google-oauth2
-  omniauth-line
   omniauth-rails_csrf_protection
   pg (~> 1.1)
   puma (>= 5.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,7 @@ module Myapp
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks])
+    config.autoload_lib(ignore: %w[assets tasks omniauth])
 
     # RSpec をデフォルトのテストフレームワークに設定
     # fixture は factory_bot で代替するため生成しない

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# 自前化した LINE ストラテジを読み込む。
+# 未メンテの gem "omniauth-line" を置き換えたもので、
+# 下部の `config.omniauth :line` より前に require する必要があるため冒頭に置く。
+require Rails.root.join("lib/omniauth/strategies/line")
+
 # Assuming you have not yet modified this file, each configuration option below
 # is set to its default value. Note that some are commented out while others
 # are not: uncommented lines are intended to protect your configuration from

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -276,7 +276,7 @@ Devise.setup do |config|
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
-  config.omniauth :line, ENV["LINE_LOGIN_KEY"], ENV["LINE_LOGIN_SECRET"], scope: "profile openid email"
+  config.omniauth :line, ENV["LINE_LOGIN_KEY"], ENV["LINE_LOGIN_SECRET"], scope: "profile"
 
   config.omniauth :google_oauth2, ENV["GOOGLE_OAUTH_CLIENT_ID"], ENV["GOOGLE_OAUTH_CLIENT_SECRET"]
 

--- a/lib/omniauth/strategies/line.rb
+++ b/lib/omniauth/strategies/line.rb
@@ -1,0 +1,49 @@
+require "omniauth-oauth2"
+require "json"
+
+module OmniAuth
+  module Strategies
+    # LINE ログイン用の OmniAuth ストラテジ。
+    # 旧 gem "omniauth-line" (0.1.0) が未メンテのため、必要な実装を自前化した。
+    # OAuth2 の共通処理（トークン交換・state 検証等）は
+    # メンテ継続中の omniauth-oauth2 に委譲し、LINE 固有の差分のみここで定義する。
+    class Line < OmniAuth::Strategies::OAuth2
+      option :name, "line"
+      option :scope, "profile openid"
+
+      option :client_options, {
+        site: "https://access.line.me",
+        authorize_url: "/oauth2/v2.1/authorize",
+        token_url: "/oauth2/v2.1/token"
+      }
+
+      # 認可画面は access.line.me、トークン取得・プロフィール取得は api.line.me を使うため
+      # コールバック時にホストを切り替える。
+      def callback_phase
+        options[:client_options][:site] = "https://api.line.me"
+        super
+      end
+
+      def callback_url
+        options[:callback_url] || (full_host + script_name + callback_path)
+      end
+
+      uid { raw_info["userId"] }
+
+      info do
+        {
+          name:        raw_info["displayName"],
+          image:       raw_info["pictureUrl"],
+          description: raw_info["statusMessage"]
+        }
+      end
+
+      # PROFILE 権限付きのアクセストークンで LINE プロフィールを取得する。
+      def raw_info
+        @raw_info ||= JSON.parse(access_token.get("v2/profile").body)
+      rescue ::Errno::ETIMEDOUT
+        raise ::Timeout::Error
+      end
+    end
+  end
+end

--- a/lib/omniauth/strategies/line.rb
+++ b/lib/omniauth/strategies/line.rb
@@ -27,11 +27,9 @@ module OmniAuth
         }
       end
 
-      # PROFILE 権限付きのアクセストークンで LINE プロフィールを取得する。
+      # 権限付きのアクセストークンで LINE プロフィールを取得する。
       def raw_info
         @raw_info ||= JSON.parse(access_token.get("v2/profile").body)
-      rescue ::Errno::ETIMEDOUT
-        raise ::Timeout::Error
       end
     end
   end

--- a/lib/omniauth/strategies/line.rb
+++ b/lib/omniauth/strategies/line.rb
@@ -3,38 +3,27 @@ require "json"
 
 module OmniAuth
   module Strategies
-    # LINE ログイン用の OmniAuth ストラテジ。
-    # 旧 gem "omniauth-line" (0.1.0) が未メンテのため、必要な実装を自前化した。
-    # OAuth2 の共通処理（トークン交換・state 検証等）は
-    # メンテ継続中の omniauth-oauth2 に委譲し、LINE 固有の差分のみここで定義する。
+    # OAuth2 の共通処理（トークン交換・state 検証等）は omniauth-oauth2 に委譲し、LINE 固有の差分のみここで定義
     class Line < OmniAuth::Strategies::OAuth2
       option :name, "line"
-      option :scope, "profile openid"
+      option :scope, "profile"
 
       option :client_options, {
-        site: "https://access.line.me",
-        authorize_url: "/oauth2/v2.1/authorize",
-        token_url: "/oauth2/v2.1/token"
+        site: "https://api.line.me",  # ベースURL
+        authorize_url: "https://access.line.me/oauth2/v2.1/authorize",  # 認可画面URL（認可だけ別ホストになる）
+        token_url: "/oauth2/v2.1/token"  # トークン取得のURL
       }
 
-      # 認可画面は access.line.me、トークン取得・プロフィール取得は api.line.me を使うため
-      # コールバック時にホストを切り替える。
-      def callback_phase
-        options[:client_options][:site] = "https://api.line.me"
-        super
-      end
-
+      # コールバックURLを明示的に指定
       def callback_url
-        options[:callback_url] || (full_host + script_name + callback_path)
+        full_host + script_name + callback_path
       end
 
-      uid { raw_info["userId"] }
+      uid { raw_info["userId"] } # LINEの一意ID → アプリのユーザー識別子
 
       info do
         {
-          name:        raw_info["displayName"],
-          image:       raw_info["pictureUrl"],
-          description: raw_info["statusMessage"]
+          name:        raw_info["displayName"]
         }
       end
 


### PR DESCRIPTION
## 概要
メンテナンス停止した gem `omniauth-line` を撤去し、LINE ログインを自前の OmniAuth ストラテジで実装。
OAuth2 の共通処理は維持されている `omniauth-oauth2` に委譲し、LINE 固有の差分のみを持つ。

## 背景
- `omniauth-line` (0.1.0) は更新が停止しており、将来 omniauth 系のアップグレードの足かせになりうる

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| lib/omniauth/strategies/line.rb | 新規 | LINE ストラテジ本体 |
| config/application.rb | 修正 | autoload_lib の ignore に omniauth を追加（Zeitwerk 名前解決の回避） |
| config/initializers/devise.rb | 修正 | ストラテジの require 追加 ＋ scope を profile に変更 |
| Gemfile | 修正 | omniauth-line を削除 |
| Gemfile.lock | 修正 | 同上（omniauth-oauth2 は Google 用 gem 依存で残存） |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - LINEログインに対応しました。
  - LINEプロフィールからユーザー識別子と表示名を取得できるようになりました。
  - LINEのプロフィール情報（詳細）を取得して連携できるようになりました。
- **改善**
  - LINE認証のスコープを `profile` に変更しました。
  - LINE向けの認証連携を、より汎用的な OAuth2 基盤に切り替え、外部専用 strategy gem への依存を減らしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->