### PR TITLE
Devise 系（registrations/sessions）のリクエストスペック追加

### DIFF
--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe "Users::Registrations", type: :request do
+  describe "GET /users/sign_up (new)" do
+    it "200" do
+      get new_user_registration_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /users (create)" do
+    it "name 付きで登録でき、authenticated_root へリダイレクト" do
+      expect {
+        post user_registration_path, params: {
+          user: { name: "新規ユーザー", email: "new@example.com",
+                  password: "password123", password_confirmation: "password123" }
+        }
+      }.to change(User, :count).by(1)
+      expect(User.last.name).to eq("新規ユーザー")
+      expect(response).to redirect_to(authenticated_root_path)
+    end
+
+    it "不正な入力では登録されない" do
+      expect {
+        post user_registration_path, params: {
+          user: { name: "", email: "bad", password: "x", password_confirmation: "y" }
+        }
+      }.not_to change(User, :count)
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+
+  describe "PATCH /users (update)" do
+    let(:user) { create(:user, password: "password123") }
+    before { sign_in user }
+
+    it "パスワードなしで name を更新でき、mypage へリダイレクト" do
+      patch user_registration_path, params: { user: { name: "更新後の名前" } }
+      expect(user.reload.name).to eq("更新後の名前")
+      expect(response).to redirect_to(mypage_path)
+    end
+  end
+end

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe "Users::Sessions", type: :request do
+  let(:user) { create(:user, password: "password123") }
+
+  describe "GET /users/sign_in (new)" do
+    it "200" do
+      get new_user_session_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /users/sign_in (create)" do
+    it "正しい資格情報でログインし、authenticated_root へリダイレクト" do
+      post user_session_path, params: { user: { email: user.email, password: "password123" } }
+      expect(response).to redirect_to(authenticated_root_path)
+    end
+
+    it "誤ったパスワードはログインできない" do
+      post user_session_path, params: { user: { email: user.email, password: "wrong" } }
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it "保護ページ閲覧後のログインは保存先(stored_location)へ戻る" do
+      get mypage_path # 未ログイン → サインインへ誘導され、遷移先が保存される
+      post user_session_path, params: { user: { email: user.email, password: "password123" } }
+      expect(response).to redirect_to(mypage_path)
+    end
+  end
+
+  describe "DELETE /users/sign_out (destroy)" do
+    it "ログアウト後 root へリダイレクト" do
+      sign_in user
+      delete destroy_user_session_path
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
未テストだった Devise カスタムコントローラにリクエストスペックを追加し、カバレッジを向上。

## 変更ファイル
| ファイル | 内容 |
|---------|------|
| spec/requests/users/registrations_spec.rb | 新規登録・パスワード不要更新の検証 |
| spec/requests/users/sessions_spec.rb | ログイン/ログアウト・stored_location の検証 |

## 実装のポイント
- registrations：`name` 許可・登録後リダイレクト（authenticated_root）・`update_without_password`
- sessions：`after_sign_in_path_for`（stored_location 分岐）・`after_sign_out_path_for`

## テスト計画
- [x] 全テスト通過（326 examples, 0 failures）
- [x] RuboCop 通過
- [x] 行カバレッジ 88.36% → **91.52%**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * ユーザー登録画面の表示、正常登録、入力エラー時の動作を検証するテストを追加しました。
  * ユーザー情報の更新とマイページへの遷移を検証するテストを追加しました。
  * サインイン画面の表示、正常・異常時の認証、ログアウト後の遷移を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->