### PR TITLE
simplecov 1.0.2 へ更新（Dependabot 対応）

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -462,7 +462,7 @@ GEM
       websocket (~> 1.0)
     shoulda-matchers (8.0.1)
       activesupport (>= 7.2)
-    simplecov (1.0.1)
+    simplecov (1.0.2)
     snaky_hash (2.0.3)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)


### PR DESCRIPTION
## 概要
Dependabot の simplecov 更新（1.0.1 → 1.0.2）を現行 develop 上で取り込む。

## 変更ファイル
- Gemfile.lock（simplecov のみ）

## テスト計画
- [x] 全テスト通過（326 examples, 0 failures）
- [x] coverage/.last_run.json 正常生成（line 91.52%）