### PR TITLE
memoryコントローラーのrender_form_failure修正

### DIFF
--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -92,7 +92,6 @@ class MemoriesController < ApplicationController
   # turbo_stream で error メッセージと flash を差し替えることで form 全体の DOM
   # (ファイル選択状態・プレビュー・テキスト入力値) を保持し、画像再選択を不要にする。
   def render_form_failure(action)
-    @available_children = policy_scope(Child).order(:birthday)
     respond_to do |format|
       format.turbo_stream do
         render turbo_stream: [
@@ -102,7 +101,10 @@ class MemoriesController < ApplicationController
           turbo_stream.replace("flash_messages", partial: "shared/flash_message")
         ], status: :unprocessable_entity
       end
-      format.html { render action, status: :unprocessable_entity }
+      format.html do
+        @available_children = policy_scope(Child).order(:birthday)
+        render action, status: :unprocessable_entity
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要
`MemoriesController#render_form_failure` で無条件に取得していた `@available_children` を `format.html` 分岐内へ移動。

## 背景
- `@available_children` はフォーム全体を再描画する html フォールバックのこども選択欄でのみ使用
- 通常の turbo_stream 経路（エラー/フラッシュのみ差し込み）では未使用なのに、`policy_scope(Child).order(:birthday)` が毎回走っていた

## 変更ファイル
- app/controllers/memories_controller.rb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * フォーム送信に失敗した際、HTML画面でも利用可能な子どもの一覧が正しく表示されるようになりました。
  * エラー状態を維持したまま、入力フォームが再表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->