### PR TITLE
libvips の untrusted ローダーを無効化

### DIFF
--- a/config/initializers/vips.rb
+++ b/config/initializers/vips.rb
@@ -1,0 +1,6 @@
+# 信頼できない画像入力に対して、libvips の「untrusted」ローダー
+# (SVG/PDF 等の外部参照を伴う危険なローダー) を無効化する。
+# Active Storage + libvips 経由の任意ファイル読み取り/RCE (CVE-2026-66066) への
+# 多層防御。本アプリは png/jpg/jpeg/webp のみ扱うため副作用はない。
+require "vips"
+Vips.block_untrusted(true)


### PR DESCRIPTION
## 概要
- libvips の untrusted ローダー（SVG/PDF 等の外部参照を伴う危険なローダー）を無効化する initializer を追加

## 背景
- Active Storage + libvips 経由の任意ファイル読み取り/RCE（CVE-2026-66066）への多層防御
- Rails 8.1.3.1 更新（#323）が根本対策。本 PR はそれに加える保険的なライブラリ層の遮断

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| config/initializers/vips.rb | 新規 | `Vips.block_untrusted(true)` で危険なローダーを一律遮断 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **セキュリティ**
  * SVGやPDFなど、外部参照を伴う画像形式の読み込みを無効化し、安全性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->